### PR TITLE
Refactor Request Wrapper to accommodate different parameter types

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function pipeLogsToTerminal(config = {}) {
   });
 
   function isValidHttpMethod(str) {
-    return typeof str === 'string' && methods.some(s => str.includes(s));
+    return typeof str === 'string' && methods.some(s => str.toLowerCase().includes(s));
   }
 
   Cypress.Commands.overwrite('server', (originalFn, options = {}) => {

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ function pipeLogsToTerminal(config = {}) {
       log = `${args[0]}`;
     }
 
-    const response = await originalFn(options).catch(async e => {
+    const response = await originalFn(...args).catch(async e => {
       let body = {};
       if (
         // check the body is there

--- a/index.js
+++ b/index.js
@@ -64,32 +64,32 @@ function pipeLogsToTerminal(config = {}) {
     }
   });
 
-  Cypress.Commands.overwrite('request', async (originalFn, options = {}) => {
-    let log = `${options.method || ''}${options.url ? ` ${options.url}` : options}`;
-
-    const response = await originalFn(options).catch(async e => {
-      let body = {};
-      if (
-        // check the body is there
-        e.onFail().toJSON().consoleProps.Yielded &&
-        e.onFail().toJSON().consoleProps.Yielded.body
-      ) {
-        body = e.onFail().toJSON().consoleProps.Yielded.body;
-      }
-
-      log += `\n${PADDING.LOG}${e.message.match(/Status:.*\d*/g)}
-      ${PADDING.LOG}Response: ${await responseBodyParser(body)}`;
-
-      logs.push(['cy:request', log]);
-      throw e;
-    });
-
-    log += `\n${PADDING.LOG}Status: ${response.status} 
-      ${PADDING.LOG}Response: ${await responseBodyParser(response.body)}`;
-
-    logs.push(['cy:request', log]);
-    return response;
-  });
+  // Cypress.Commands.overwrite('request', async (originalFn, options = {}) => {
+  //   let log = `${options.method || ''}${options.url ? ` ${options.url}` : options}`;
+  //
+  //   const response = await originalFn(options).catch(async e => {
+  //     let body = {};
+  //     if (
+  //       // check the body is there
+  //       e.onFail().toJSON().consoleProps.Yielded &&
+  //       e.onFail().toJSON().consoleProps.Yielded.body
+  //     ) {
+  //       body = e.onFail().toJSON().consoleProps.Yielded.body;
+  //     }
+  //
+  //     log += `\n${PADDING.LOG}${e.message.match(/Status:.*\d*/g)}
+  //     ${PADDING.LOG}Response: ${await responseBodyParser(body)}`;
+  //
+  //     logs.push(['cy:request', log]);
+  //     throw e;
+  //   });
+  //
+  //   log += `\n${PADDING.LOG}Status: ${response.status}
+  //     ${PADDING.LOG}Response: ${await responseBodyParser(response.body)}`;
+  //
+  //   logs.push(['cy:request', log]);
+  //   return response;
+  // });
 
   Cypress.Commands.overwrite('server', (originalFn, options = {}) => {
     const prevCallback = options && options.onAnyResponse;

--- a/index.js
+++ b/index.js
@@ -70,7 +70,7 @@ function pipeLogsToTerminal(config = {}) {
     // args can have up to 3 arguments
     // https://docs.cypress.io/api/commands/request.html#Syntax
     if (args[0].method) {
-      log = `${args[0].method} ${args[0].url}`;
+      log = `${args[0].method} ${args[0].url ? `${args[0].url}` : args[0]}`;
     } else if (isValidHttpMethod(args[0])) {
       log = `${args[0]} ${args[1]}`;
     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-terminal-report",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -54,6 +54,11 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   },
   "homepage": "https://github.com/archfz/cypress-terminal-report#readme",
   "dependencies": {
-    "chalk": "^3.0.0"
+    "chalk": "^3.0.0",
+    "methods": "^1.1.2"
   },
   "peerDependencies": {
     "cypress": "^3.8.1"

--- a/test/cypress/integration/requests.spec.js
+++ b/test/cypress/integration/requests.spec.js
@@ -2,6 +2,8 @@ describe('Requests.', () => {
 
   it('GET should pass', () => {
     cy.request('https://jsonplaceholder.cypress.io/todos/1');
+    cy.request('GET', 'https://jsonplaceholder.cypress.io/todos/2');
+    cy.request('GET', 'https://jsonplaceholder.cypress.io/todos/3', 'mock body');
   });
 
   it('POST should pass', () => {

--- a/test/test.js
+++ b/test/test.js
@@ -107,6 +107,12 @@ describe('cypress-terminal-report', () => {
         'cy:request ✔  https://jsonplaceholder.cypress.io/todos/1\n\t\t    Status: 200 \n      \t\t    Response: {\n\t\t      "userId": 1,\n\t\t      "id": 1,\n\t\t      "title": "delectus aut autem",\n\t\t      "completed": false\n\t\t    }'
       );
       expect(stdout).to.contain(
+        'cy:request ✔  GET https://jsonplaceholder.cypress.io/todos/2\n\t\t    Status: 200 \n      \t\t    Response: {\n\t\t      "userId": 1,\n\t\t      "id": 2,\n\t\t      "title": "quis ut nam facilis et officia qui",\n\t\t      "completed": false\n\t\t    }'
+      );
+      expect(stdout).to.contain(
+        'cy:request ✔  GET https://jsonplaceholder.cypress.io/todos/3\n\t\t    Status: 200 \n      \t\t    Response: {\n\t\t      "userId": 1,\n\t\t      "id": 3,\n\t\t      "title": "fugiat veniam minus",\n\t\t      "completed": false\n\t\t    }'
+      );
+      expect(stdout).to.contain(
         'cy:request ✔  POST https://jsonplaceholder.cypress.io/comments\n\t\t    Status: 201 \n      \t\t    Response: {\n\t\t      "id": 501\n\t\t    }\n\n\n\n\r'
       );
       // log failed command


### PR DESCRIPTION
I stumbled upon this because our application was using the `cy.request(method, url)` syntax. Originally, the wrapper for request was only handling calls that passed an options object. This PR allows the wrapper to accommodate the other parameter types listed here: https://docs.cypress.io/api/commands/request.html#Syntax

I also added some extra test cases to cover the different ways request can be called.