### PR TITLE
Check if there are logs before accessing last element (fixes #20)

### DIFF
--- a/src/installLogsCollector.js
+++ b/src/installLogsCollector.js
@@ -37,8 +37,10 @@ function installLogsCollector(config = {}) {
   }
 
   Cypress.on('fail', error => {
-    const [type, message] = logs[logs.length - 1];
-    logs[logs.length - 1] = [type, message, CONSTANTS.SEVERITY.ERROR];
+    if (logs.length !== 0) {
+      const [type, message] = logs[logs.length - 1];
+      logs[logs.length - 1] = [type, message, CONSTANTS.SEVERITY.ERROR];
+    }
     throw error;
   });
 

--- a/test/cypress/integration/skippedTest.spec.js
+++ b/test/cypress/integration/skippedTest.spec.js
@@ -1,0 +1,8 @@
+describe('Skipped test', () => {
+  before(function() {
+    this.skip();
+  });
+
+  it('Skipped test', () => {
+  });
+});


### PR DESCRIPTION
Running tests locally didn't work for me (using `npm run test` within `test`), so let's see if it works on Travis.