### PR TITLE
Add support for custom log collector

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,12 @@ logs will be printed to console for successful tests as well as failing ones.
 string; Default: 'onFail'. When to print logs to file(s), possible values: 'always', 'onFail', 'never' - When set to always
 logs will be printed to file(s) for successful tests as well as failing ones.
 
+#### `options.collectTestLogs`
+([spec, test, state], [type, message, severity][]) => void; default: undefined;
+Callback to collect each test case's logs after its run.
+The first argument contains information about the test: the `spec` (test file), `test` (test title) and `state` (test state) fields.
+The second argument contains the test logs. 'type' is from the same list as for the `collectTypes` support install option (see below). Severity can be of ['', 'error', 'warning'].
+
 <br/>
 
 ### _Options for the support install_

--- a/README.md
+++ b/README.md
@@ -100,6 +100,12 @@ null | ([type, message, severity]) => boolean; default: undefined;
 Callback to filter logs manually.
 The type is from the same list as for the `collectTypes` option. Severity can be of ['', 'error', 'warning'].
 
+#### `options.collectTestLogs`
+(context, [type, message, severity][]) => void; default: undefined;
+Callback to collect each test case's logs after its run.
+The context is Mocha's `this` value in its `afterEach` hook, containing `test`, `currentTest` etc. fields.
+The type is from the same list as for the `collectTypes` option. Severity can be of ['', 'error', 'warning'].
+
 #### `options.xhr.printHeaderData` 
 boolean; default false; Whether to print header data for XHR requests.
 

--- a/src/installLogsCollector.js
+++ b/src/installLogsCollector.js
@@ -91,6 +91,9 @@ function installLogsCollector(config = {}) {
   afterEach(function () {
     // Need to wait otherwise some last commands get omitted from logs.
     cy.wait(3, {log: false});
+    if (config.collectTestLogs) {
+      config.collectTestLogs(this, logs);
+    }
     cy.task(CONSTANTS.TASK_NAME, {
       spec: this.test.file,
       test: this.currentTest.title,
@@ -121,6 +124,9 @@ function validateConfig(config) {
 
   if (config.filterLog && typeof config.filterLog !== 'function') {
     throw new CtrError(`[cypress-terminal-report] Filter log option expected to be a function.`);
+  }
+  if (config.collectTestLogs && typeof config.collectTestLogs !== 'function') {
+    throw new CtrError(`[cypress-terminal-report] Collect test logs option expected to be a function.`);
   }
 }
 

--- a/src/installLogsCollector.schema.json
+++ b/src/installLogsCollector.schema.json
@@ -28,6 +28,9 @@
     "filterLog": {
       "type": "function"
     },
+    "collectTestLogs": {
+      "type": "function"
+    },
     "xhr": {
       "type": "object",
       "properties": {

--- a/src/installLogsPrinter.js
+++ b/src/installLogsPrinter.js
@@ -54,6 +54,7 @@ let outputProcessors = [];
  *      - outputRoot?: The root path to output log files to.
  *      - outputTarget?: Log output types. {[filePath: string]: string | function}
  *      - compactLogs?: Number of lines to compact around failing commands.
+ *      - collectTestLogs?: Callback to collect each test case's logs after its run.
  */
 function installLogsPrinter(on, options = {}) {
   options.printLogsToFile = options.printLogsToFile || "onFail";
@@ -82,6 +83,10 @@ function installLogsPrinter(on, options = {}) {
       if ((options.printLogsToConsole === "onFail" && data.state !== "passed")
         || options.printLogsToConsole === "always") {
         logToTerminal(messages, options);
+      }
+
+      if (options.collectTestLogs) {
+        options.collectTestLogs({ spec: data.spec, test: data.test, state: data.state }, messages);
       }
 
       return null;

--- a/src/installLogsPrinter.schema.json
+++ b/src/installLogsPrinter.schema.json
@@ -46,6 +46,9 @@
           ]
         }
       }
+    },
+    "collectTestLogs": {
+      "type": "function"
     }
   },
   "dependencies": {

--- a/test/cypress/plugins/index.js
+++ b/test/cypress/plugins/index.js
@@ -50,6 +50,7 @@ module.exports = (on, config) => {
       printLogsToConsole: true,
       printLogsToFile: true,
       shouldNotBeHere: "",
+      collectTestLogs: "",
     };
   }
   if (config.env.printLogsToConsoleAlways == '1') {
@@ -63,6 +64,10 @@ module.exports = (on, config) => {
   }
   if (config.env.printLogsToFileNever == '1') {
     options.printLogsToFile = 'never';
+  }
+  if (config.env.collectTestLogs == '1') {
+    options.collectTestLogs = (context, logs) =>
+      console.log(`Collected ${logs.length} logs for test "${context.test}", last log: ${logs[logs.length - 1]}`);
   }
 
   require('../../../src/installLogsPrinter')(on, options);

--- a/test/cypress/support/index.js
+++ b/test/cypress/support/index.js
@@ -9,6 +9,10 @@ if (env.setLogTypes == '1') {
 if (env.setFilterLogs == '1') {
   config.filterLog = ([,log]) => log.indexOf('[filter-out-string]') !== -1;
 }
+if (env.setCollectTestLogs == '1') {
+  config.collectTestLogs = (context, logs) =>
+    cy.log(`Collected ${logs.length} logs for test "${context.currentTest.title}", last log: ${logs[logs.length - 1]}`);
+}
 if (env.printHeaderData == '1') {
   config.xhr = config.xhr || {};
   config.xhr.printHeaderData = true;
@@ -24,6 +28,7 @@ if (env.supportBadConfig == '1') {
   config = {
     collectTypes: 0,
     filterLog: "string",
+    collectTestLogs: "string",
     xhr: {
       printRequestData: "",
       printHeaderData: "",

--- a/test/test.js
+++ b/test/test.js
@@ -268,6 +268,13 @@ describe('cypress-terminal-report', () => {
     });
   }).timeout(60000);
 
+  it('Should collect test logs if support configuration added.', async () => {
+    await runTest(commandBase(['setCollectTestLogs=1'], ['allTypesOfLogs.spec.js']), (error, stdout, stderr) => {
+      expect(stdout).to.contain(`Collected 17 logs for test "All types of logs."`);
+      expect(stdout).to.contain(`last log: cy:command,get\t.breaking-get [filter-out-string],error`);
+    });
+  }).timeout(60000);
+
   it('Should generate proper log output files, and print only failing ones if config is on default.', async () => {
     const outRoot = {};
     const testOutputs = {};
@@ -362,6 +369,7 @@ describe('cypress-terminal-report', () => {
       expect(stdout).to.contain(`[cypress-terminal-report] Invalid plugin install options:`);
       expect(stdout).to.contain(`=> .collectTypes: Invalid type: number (expected array)`);
       expect(stdout).to.contain(`=> .filterLog: Invalid type: string (expected function)`);
+      expect(stdout).to.contain(`=> .collectTestLogs: Invalid type: string (expected function)`);
       expect(stdout).to.contain(`=> .xhr/printRequestData: Invalid type: string (expected boolean)`);
       expect(stdout).to.contain(`=> .xhr/printHeaderData: Invalid type: string (expected boolean)`);
       expect(stdout).to.contain(`=> .xhr/shouldNotBeHere: Additional properties not allowed`);

--- a/test/test.js
+++ b/test/test.js
@@ -361,6 +361,7 @@ describe('cypress-terminal-report', () => {
       expect(stdout).to.contain(`=> .shouldNotBeHere: Additional properties not allowed`);
       expect(stdout).to.contain(`=> .printLogsToFile: Invalid type: boolean (expected string)`);
       expect(stdout).to.contain(`=> .printLogsToConsole: Invalid type: boolean (expected string)`);
+      expect(stdout).to.contain(`=> .collectTestLogs: Invalid type: string (expected function)`);
     });
   }).timeout(60000);
 
@@ -389,4 +390,11 @@ describe('cypress-terminal-report', () => {
       });
     });
   }).timeout(90000);
+
+  it('Should collect test logs if plugin configuration added.', async () => {
+    await runTest(commandBase(['collectTestLogs=1'], ['allTypesOfLogs.spec.js']), (error, stdout, stderr) => {
+      expect(stdout).to.contain(`Collected 17 logs for test "All types of logs."`);
+      expect(stdout).to.contain(`last log: cy:command,get\t.breaking-get [filter-out-string],error`);
+    });
+  }).timeout(60000);
 });


### PR DESCRIPTION
Add a `collectTestLogs` callback function to both _support_ (browser-side) and _plugin_ (Node-side) options, to collect each test case's logs after its run.

Solves #56.