### PR TITLE
Allow for multiple dots in spec name

### DIFF
--- a/src/outputProcessor/NestedOutputProcessorDecorator.js
+++ b/src/outputProcessor/NestedOutputProcessorDecorator.js
@@ -21,7 +21,7 @@ module.exports = class NestedOutputProcessorDecorator {
   write(allMessages) {
     Object.entries(allMessages).forEach(([spec, messages]) => {
       const relativeSpec = path.relative(this.specRoot, spec);
-      const outPath = path.join(this.root, relativeSpec.replace(/\..+$/, `.${this.ext}`));
+      const outPath = path.join(this.root, relativeSpec.replace(new RegExp(path.extname(relativeSpec) + '$'), `.${this.ext}`));
       const processor = this.decoratedFactory(outPath);
 
       this.decoratedProcessors.push(processor);


### PR DESCRIPTION
Assuming `relativeSpec` is `path/to/spec/file.with.dots.in.name.js`
The current code
```js
relativeSpec.replace(/\..+$/, `.${this.ext}`)
```
would result in `path/to/spec/file.txt`

And if we have multiple files with `file` prefix, i.e. `file.with.dots.in.name.js` and `file.name.with.dots.js`, it would result in the logs being overwritten.

This PR only replaces the extension found at the end of the file with that with the extension given to the decorator.
That way the logs will still remain unique within that given directory.
