### PR TITLE
Update XHR logs with response data when it arrives

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ integer; default: 800; Max length of cy.log and console.warn/console.error.
 integer; default: 800; Max length of cy commands.
 
 #### `options.routeTrimLength`
-integer; default: 5000; Max length of cy.route request data.
+integer; default: 5000; Max length of cy.route, cy.request or XHR data.
 
 #### `options.compactLogs` 
 integer?; default: null; If it is set to a number greater or equal to 0, this amount of logs 

--- a/src/installLogsPrinter.js
+++ b/src/installLogsPrinter.js
@@ -234,6 +234,7 @@ function logToTerminal(messages, options) {
     } else if (type === LOG_TYPES.CYPRESS_XHR) {
       color = 'green';
       icon = LOG_SYMBOLS.info;
+      trim = options.routeTrimLength || 5000;
     } else if (type === LOG_TYPES.CYPRESS_ROUTE) {
       color = 'green';
       icon = LOG_SYMBOLS.route;

--- a/test/cypress/integration/xhrTypes.spec.js
+++ b/test/cypress/integration/xhrTypes.spec.js
@@ -38,4 +38,40 @@ describe('XHR all types.', () => {
     cy.get('.breaking-get', {timeout: 1});
   });
 
+  it('XHR responses not handled by cy.route', () => {
+    cy.visit('/commands/network-requests');
+
+    // Succeeding GET request
+    cy.get('.network-comment').should('not.contain', 'laudantium enim quasi');
+    cy.get('.network-btn').click();
+    cy.get('.network-comment').should('contain', 'laudantium enim quasi');
+
+    // Failing GET request
+    cy.window().then((window) => {
+      const document = window.document;
+
+      // Create a div to put a message to after receiving the XHR response
+      const networkErrorMessage = document.createElement('div');
+      networkErrorMessage.className = 'network-error-message';
+      const networkComment = document.querySelector('.network-comment');
+      networkComment.after(networkErrorMessage);
+
+      // Crate a button that triggers the XHR to a failing URL
+      const networkErrorButton = document.createElement('button');
+      networkErrorButton.className = 'network-error btn btn-primary';
+      networkErrorButton.innerHTML = 'Request error';
+      networkErrorButton.addEventListener('click', () =>
+        window.fetch('https://www.mocky.io/v2/5ec993803000009700a6ce1f')
+          .then(() => {
+            networkErrorMessage.innerHTML = 'received response';
+          }));
+      networkErrorMessage.before(networkErrorButton);
+    });
+    cy.get('.network-error-message').should('not.contain', 'received response');
+    cy.get('.network-error').click();
+    cy.get('.network-error-message').should('contain', 'received response');
+
+    cy.get('.breaking-get', {timeout: 100}); // longer timeout to ensure XHR log update is included
+  });
+
 });

--- a/test/output/out.spec.always.json
+++ b/test/output/out.spec.always.json
@@ -19,7 +19,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "GET https://jsonplaceholder.cypress.io/comments/1"
+        "message": "GET https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 200 - OK"
       },
       {
         "type": "cy:command",
@@ -54,7 +54,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "POST https://jsonplaceholder.cypress.io/comments"
+        "message": "POST https://jsonplaceholder.cypress.io/comments (X ms)\nStatus: 201 - Created"
       },
       {
         "type": "cy:command",
@@ -178,8 +178,8 @@
       },
       {
         "type": "cy:xhr",
-        "severity": "success",
-        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1"
+        "severity": "warning",
+        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 404 - Not Found"
       },
       {
         "type": "cy:command",

--- a/test/output/out.spec.always.txt
+++ b/test/output/out.spec.always.txt
@@ -3,7 +3,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): visit	/commands/network-requests
         cy:command (K): get	.network-btn
         cy:command (K): click
-            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 200 - OK
         cy:command (K): wait	@getComment
           cy:route (K): (getComment) GET https://jsonplaceholder.cypress.io/comments/1
                         Status: 200
@@ -18,7 +19,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): assert	expected **200** to equal **200**
         cy:command (K): get	.network-post
         cy:command (K): click
-            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments
+            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments (X ms)
+                        Status: 201 - Created
         cy:command (K): wait	@postComment
           cy:route (K): (postComment) POST https://jsonplaceholder.cypress.io/comments
                         Status: 201
@@ -67,7 +69,8 @@ cypress/integration/happyFlow.spec.js:
          cons:info (K): This should console.info appear.
         cy:command (K): get	.network-put
         cy:command (K): click
-            cy:xhr (K): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (!): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 404 - Not Found
         cy:command (K): wait	@putComment
           cy:route (!): (putComment) PUT https://jsonplaceholder.cypress.io/comments/1
                         Status: 404

--- a/test/output/out.spec.onFail.json
+++ b/test/output/out.spec.onFail.json
@@ -19,7 +19,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "GET https://jsonplaceholder.cypress.io/comments/1"
+        "message": "GET https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 200 - OK"
       },
       {
         "type": "cy:command",
@@ -54,7 +54,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "POST https://jsonplaceholder.cypress.io/comments"
+        "message": "POST https://jsonplaceholder.cypress.io/comments (X ms)\nStatus: 201 - Created"
       },
       {
         "type": "cy:command",
@@ -178,8 +178,8 @@
       },
       {
         "type": "cy:xhr",
-        "severity": "success",
-        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1"
+        "severity": "warning",
+        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 404 - Not Found"
       },
       {
         "type": "cy:command",

--- a/test/output/out.spec.onFail.txt
+++ b/test/output/out.spec.onFail.txt
@@ -3,7 +3,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): visit	/commands/network-requests
         cy:command (K): get	.network-btn
         cy:command (K): click
-            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 200 - OK
         cy:command (K): wait	@getComment
           cy:route (K): (getComment) GET https://jsonplaceholder.cypress.io/comments/1
                         Status: 200
@@ -18,7 +19,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): assert	expected **200** to equal **200**
         cy:command (K): get	.network-post
         cy:command (K): click
-            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments
+            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments (X ms)
+                        Status: 201 - Created
         cy:command (K): wait	@postComment
           cy:route (K): (postComment) POST https://jsonplaceholder.cypress.io/comments
                         Status: 201
@@ -67,7 +69,8 @@ cypress/integration/happyFlow.spec.js:
          cons:info (K): This should console.info appear.
         cy:command (K): get	.network-put
         cy:command (K): click
-            cy:xhr (K): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (!): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 404 - Not Found
         cy:command (K): wait	@putComment
           cy:route (!): (putComment) PUT https://jsonplaceholder.cypress.io/comments/1
                         Status: 404

--- a/test/output_nested_spec/json/happyFlow.spec.json
+++ b/test/output_nested_spec/json/happyFlow.spec.json
@@ -19,7 +19,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "GET https://jsonplaceholder.cypress.io/comments/1"
+        "message": "GET https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 200 - OK"
       },
       {
         "type": "cy:command",
@@ -54,7 +54,7 @@
       {
         "type": "cy:xhr",
         "severity": "success",
-        "message": "POST https://jsonplaceholder.cypress.io/comments"
+        "message": "POST https://jsonplaceholder.cypress.io/comments (X ms)\nStatus: 201 - Created"
       },
       {
         "type": "cy:command",
@@ -178,8 +178,8 @@
       },
       {
         "type": "cy:xhr",
-        "severity": "success",
-        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1"
+        "severity": "warning",
+        "message": "STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)\nStatus: 404 - Not Found"
       },
       {
         "type": "cy:command",

--- a/test/output_nested_spec/txt/happyFlow.spec.txt
+++ b/test/output_nested_spec/txt/happyFlow.spec.txt
@@ -3,7 +3,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): visit	/commands/network-requests
         cy:command (K): get	.network-btn
         cy:command (K): click
-            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (K): GET https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 200 - OK
         cy:command (K): wait	@getComment
           cy:route (K): (getComment) GET https://jsonplaceholder.cypress.io/comments/1
                         Status: 200
@@ -18,7 +19,8 @@ cypress/integration/happyFlow.spec.js:
         cy:command (K): assert	expected **200** to equal **200**
         cy:command (K): get	.network-post
         cy:command (K): click
-            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments
+            cy:xhr (K): POST https://jsonplaceholder.cypress.io/comments (X ms)
+                        Status: 201 - Created
         cy:command (K): wait	@postComment
           cy:route (K): (postComment) POST https://jsonplaceholder.cypress.io/comments
                         Status: 201
@@ -67,7 +69,8 @@ cypress/integration/happyFlow.spec.js:
          cons:info (K): This should console.info appear.
         cy:command (K): get	.network-put
         cy:command (K): click
-            cy:xhr (K): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1
+            cy:xhr (!): STUBBED PUT https://jsonplaceholder.cypress.io/comments/1 (X ms)
+                        Status: 404 - Not Found
         cy:command (K): wait	@putComment
           cy:route (!): (putComment) PUT https://jsonplaceholder.cypress.io/comments/1
                         Status: 404


### PR DESCRIPTION
Update XHR logs with server response data when it arrives:
- always show response status code and description, in the same format as we do for cy.request
- always show request duration (as reported by Cypress)
- show response body if the status code is a non-successful one and we haven't already logged the response body in a cy:route log

This required quite a lot of changes but most of them are related to tests. We might also want to document when the XHR response body is included in the logs, but I didn't find a suitable existing place in the README, and that can also be done separately if wanted.

Solves #61.