### PR TITLE
fix: Handle top level pending suites when extended collecting

### DIFF
--- a/src/collector/LogCollectExtendedControl.js
+++ b/src/collector/LogCollectExtendedControl.js
@@ -291,6 +291,9 @@ module.exports = class LogCollectExtendedControl extends LogCollectBaseControl {
     const recursiveSuites = (suites) => {
       if (suites) {
         suites.forEach((suite) => {
+          if (suite.isPending()) {
+            return
+          }
           suite.afterAll(hookCallback);
           // Make sure our hook is first so that other after all hook logs come after
           // the failed before all hooks logs.

--- a/test/cypress/integration/skipTopLevelSuite.spec.js
+++ b/test/cypress/integration/skipTopLevelSuite.spec.js
@@ -1,0 +1,6 @@
+describe.skip('It skips', () => {
+  it("A skipped test", () => {
+    cy.visit('/');
+    cy.contains('cypress', { timeout: 1 });
+  })
+})

--- a/test/test.js
+++ b/test/test.js
@@ -634,6 +634,12 @@ describe('cypress-terminal-report', () => {
     });
   }).timeout(60000);
 
+  it('Should not error with extended collector when a top level suite is skipped', async function () {
+    await runTest(commandBase(['enableExtendedCollector=1'], ['skipTopLevelSuite.spec.js']), (error, stdout, stderr) => {
+      expect(clean(stdout)).to.contain(clean(`1 pending`))
+    });
+  }).timeout(60000);
+
   /*
    * -------------------
    * Cucumber support. |


### PR DESCRIPTION
If a suite is pending, do not attempt to add the after hooks
for extended log collecting