### PR TITLE
export public api / types used by installLogsPrinter / installLogsCollector

### DIFF
--- a/src/installLogsCollector.d.ts
+++ b/src/installLogsCollector.d.ts
@@ -1,6 +1,6 @@
-type Severity = '' | 'error' | 'warning';
+export type Severity = '' | 'error' | 'warning';
 
-interface SupportOptions {
+export interface SupportOptions {
   /**
    * What types of logs to collect and print.
    * By default all types are enabled.

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
 
-type Severity = '' | 'error' | 'warning';
+export type Severity = '' | 'error' | 'warning';
 
-interface PluginOptions {
+export interface PluginOptions {
   /**
    * Max length of cy.log and console.warn/console.error.
    * @default 800

--- a/test/cypress/integration/fetchApi.spec.js
+++ b/test/cypress/integration/fetchApi.spec.js
@@ -18,12 +18,12 @@ describe('Fetch Api', () => {
       fetch('/comments/10', {
         method: 'PUT',
         body: 'test',
-      });
+      }).catch(console.error);
     });
 
-    cy.wait('@putComment');
+    cy.wait('@putComment', {timeout: 1000});
 
-    cy.get('.breaking-get', {timeout: 1});
+    cy.get('.breaking-get', {timeout: 100});
   })
 
   context('Timeout', () => {
@@ -46,12 +46,12 @@ describe('Fetch Api', () => {
         fetch('/comments/10', {
           method: 'PUT',
           body: 'test',
-        });
+        }).catch(console.error);
       });
   
-      cy.wait('@putComment');
+      cy.wait('@putComment', {timeout: 1000});
   
-      cy.get('.breaking-get', {timeout: 1});
+      cy.get('.breaking-get', {timeout: 100});
     });
 
     // Currently Cypress can't handle fetch Abort properly. It produces an unhandled entry, while the request remains "pending":
@@ -79,10 +79,10 @@ describe('Fetch Api', () => {
           method: 'PUT',
           body: 'test',
           signal: controller.signal
-        });
+        }).catch(console.error);
       });
   
-      cy.wait('@putComment');
+      cy.wait('@putComment', {timeout: 1000});
   
       cy.get('.breaking-get', {timeout: 1});
     });
@@ -114,7 +114,7 @@ describe('Fetch Api', () => {
         button.addEventListener('click', () =>
           fetch(options.url).then(() => {
             containerDiv.innerHTML = 'received response';
-          })
+          }).catch(console.error)
         );
         containerDiv.before(button);
       });


### PR DESCRIPTION
As `installLogsPrinter` and `installLogsCollector` are exported, then the inner types should also be exported:

`installLogsPrinter.d.ts`:
* `PluginOptions`
* `Severity`
`installLogsCollector.d.ts`:
* `SupportOptions`
* `Severity`

Funny note:
`Severity` is redundant and might be moved to a common place some day when the repo will be migrated to typescript, also the typpings would be emitted by `tsc` so they would not need any manual maintainance