### PR TITLE
Fix spec file bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ directory. You should add `it.only` to the test case you are working on to speed
 
 #### 3.5.2
 
-- Fix issue where suites in sub-files called by top-level `.spec` files get put into a different output file than the top-level `.spec` log file.  by [bvandercar-vt](https://github.com/bvandercar-vt)
+- Fix issue where top-level `.spec` files that call test functions in other files results in multiple output files being created.  by [bvandercar-vt](https://github.com/bvandercar-vt)
 
 #### 3.5.1
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,10 @@ directory. You should add `it.only` to the test case you are working on to speed
 
 ## Release Notes
 
+#### 3.5.2
+
+- Fix issue where suites in sub-files called by top-level `.spec` files get put into a different output file than the top-level `.spec` log file.  by [bvandercar-vt](https://github.com/bvandercar-vt)
+
 #### 3.5.1
 
 - Fix custom output processor example in README. by [bvandercar-vt](https://github.com/bvandercar-vt)

--- a/src/collector/LogCollectExtendedControl.js
+++ b/src/collector/LogCollectExtendedControl.js
@@ -32,11 +32,11 @@ module.exports = class LogCollectExtendedControl extends LogCollectBaseControl {
     let testState = options.state || mochaRunnable.state;
     let testTitle = options.title || mochaRunnable.title;
     let testLevel = 0;
-    let invocationDetails;
 
+    let invocationDetails = mochaRunnable.invocationDetails;
     {
       // always get top-most spec to determine the called .spec file
-      let parent = mochaRunnable;
+      let parent = mochaRunnable.parent;
       while (parent && parent.invocationDetails) {
         invocationDetails = parent.invocationDetails
         parent = parent.parent;

--- a/src/collector/LogCollectExtendedControl.js
+++ b/src/collector/LogCollectExtendedControl.js
@@ -32,18 +32,28 @@ module.exports = class LogCollectExtendedControl extends LogCollectBaseControl {
     let testState = options.state || mochaRunnable.state;
     let testTitle = options.title || mochaRunnable.title;
     let testLevel = 0;
+    let invocationDetails;
 
-    let invocationDetails = (mochaRunnable.parent.invocationDetails || mochaRunnable.invocationDetails);
+    {
+      // always get top-most spec to determine the called .spec file
+      let parent = mochaRunnable;
+      while (parent && parent.invocationDetails) {
+        invocationDetails = parent.invocationDetails
+        parent = parent.parent;
+      }
+    }
+    
     let spec = invocationDetails.relativeFile || invocationDetails.fileUrl.replace(/^[^?]+\?p=/, '');
     let wait = typeof options.wait === 'number' ? options.wait : 6;
 
-    let parent = mochaRunnable.parent;
-    while (parent && parent.title) {
-      testTitle = `${parent.title} -> ${testTitle}`
-      parent = parent.parent;
-      ++testLevel;
+    {
+      let parent = mochaRunnable.parent;
+      while (parent && parent.title) {
+        testTitle = `${parent.title} -> ${testTitle}`
+        parent = parent.parent;
+        ++testLevel;
+      }
     }
-
 
     const prepareLogs = () => {
       return this.prepareLogs(logStackIndex, {mochaRunnable, testState, testTitle, testLevel});

--- a/src/collector/LogCollectSimpleControl.js
+++ b/src/collector/LogCollectSimpleControl.js
@@ -26,11 +26,11 @@ module.exports = class LogCollectSimpleControl extends LogCollectBaseControl {
     let testState = options.state || mochaRunnable.state;
     let testTitle = options.title || mochaRunnable.title;
     let testLevel = 0;
-    let invocationDetails;
 
+    let invocationDetails = mochaRunnable.invocationDetails;
     {
       // always get top-most spec to determine the called .spec file
-      let parent = mochaRunnable;
+      let parent = mochaRunnable.parent;
       while (parent && parent.invocationDetails) {
         invocationDetails = parent.invocationDetails
         parent = parent.parent;

--- a/src/collector/LogCollectSimpleControl.js
+++ b/src/collector/LogCollectSimpleControl.js
@@ -26,16 +26,27 @@ module.exports = class LogCollectSimpleControl extends LogCollectBaseControl {
     let testState = options.state || mochaRunnable.state;
     let testTitle = options.title || mochaRunnable.title;
     let testLevel = 0;
+    let invocationDetails;
 
-    let invocationDetails = (mochaRunnable.parent.invocationDetails || mochaRunnable.invocationDetails);
+    {
+      // always get top-most spec to determine the called .spec file
+      let parent = mochaRunnable;
+      while (parent && parent.invocationDetails) {
+        invocationDetails = parent.invocationDetails
+        parent = parent.parent;
+      }
+    }
+
     let spec = invocationDetails.relativeFile || invocationDetails.fileUrl.replace(/^[^?]+\?p=/, '');
     let wait = typeof options.wait === 'number' ? options.wait : 6;
 
-    let parent = mochaRunnable.parent;
-    while (parent && parent.title) {
-      testTitle = `${parent.title} -> ${testTitle}`
-      parent = parent.parent;
-      ++testLevel;
+    {
+      let parent = mochaRunnable.parent;
+      while (parent && parent.title) {
+        testTitle = `${parent.title} -> ${testTitle}`
+        parent = parent.parent;
+        ++testLevel;
+      }
     }
 
     const prepareLogs = () => {

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -22,7 +22,7 @@ export class BaseOutputProcessor {
   initialContent: string;
   chunkSeparator: string;
 
-  writeSpecChunk(spec: string, chunk: string, pos?: number);
+  writeSpecChunk(spec: string, chunk: string, pos?: number): void;
 }
 
 

--- a/test/cypress/integration/callsSuiteInAnotherFile.spec.js
+++ b/test/cypress/integration/callsSuiteInAnotherFile.spec.js
@@ -1,0 +1,14 @@
+import {callSuite} from './suiteInOtherFile'
+
+describe('Calls function in another file that creates a sub-suite.', () => {
+  it('the test 1', () => {
+    cy.log('log test 1');
+    expect(1).to.equal(1);
+  });
+  it('the test 2', () => {
+    cy.log('log test 2');
+    expect(1).to.equal(2);
+  });
+
+  callSuite()
+});

--- a/test/cypress/integration/suiteInOtherFile.js
+++ b/test/cypress/integration/suiteInOtherFile.js
@@ -1,0 +1,12 @@
+module.exports = {
+  callSuite: function (){
+    context('sub-suite in different file', () => {
+      it('subsuite test 1', () => {
+        cy.log('subsuite test 1');
+      });
+      it('subsuite test 2', () => {
+        expect(1).to.equal(2);
+      });
+    })
+  }
+};

--- a/test/output_nested_spec/custom/callsSuiteInAnotherFile.spec.cst
+++ b/test/output_nested_spec/custom/callsSuiteInAnotherFile.spec.cst
@@ -1,0 +1,2 @@
+Specs:
+cypress/integration/callsSuiteInAnotherFile.spec.js

--- a/test/output_nested_spec/json/callsSuiteInAnotherFile.spec.json
+++ b/test/output_nested_spec/json/callsSuiteInAnotherFile.spec.json
@@ -1,0 +1,18 @@
+{
+  "cypress/integration/callsSuiteInAnotherFile.spec.js": {
+    "Calls function in another file that creates a sub-suite. -> the test 2": [
+      {
+        "type": "cy:command",
+        "severity": "error",
+        "message": "assert\texpected **1** to equal **2**"
+      }
+    ],
+    "Calls function in another file that creates a sub-suite. -> sub-suite in different file -> subsuite test 2": [
+      {
+        "type": "cy:command",
+        "severity": "error",
+        "message": "assert\texpected **1** to equal **2**"
+      }
+    ]
+  }
+}

--- a/test/output_nested_spec/txt/callsSuiteInAnotherFile.spec.txt
+++ b/test/output_nested_spec/txt/callsSuiteInAnotherFile.spec.txt
@@ -1,0 +1,7 @@
+cypress/integration/callsSuiteInAnotherFile.spec.js:
+    Calls function in another file that creates a sub-suite. -> the test 2
+        cy:command (X): assert	expected **1** to equal **2**
+
+    Calls function in another file that creates a sub-suite. -> sub-suite in different file -> subsuite test 2
+        cy:command (X): assert	expected **1** to equal **2**
+

--- a/test/specs/outputToFiles.spec.js
+++ b/test/specs/outputToFiles.spec.js
@@ -77,7 +77,13 @@ describe('Output to files.', () => {
   }).timeout(90000);
 
   it('Should generate proper nested log output files.', async () => {
-    const specFiles = ['requests.spec.js', 'happyFlow.spec.js', 'printLogsSuccess.spec.js', 'multiple.dots.in.spec.js'];
+    const specFiles = [
+      'requests.spec.js', 
+      'happyFlow.spec.js', 
+      'printLogsSuccess.spec.js', 
+      'multiple.dots.in.spec.js', 
+      'callsSuiteInAnotherFile.spec.js'
+    ];
     await runTest(commandBase(['generateNestedOutput=1'], specFiles), (error, stdout) => {
       const specs = glob.sync('./output_nested_spec/**/*', {nodir: true});
       specs.forEach(specFile => {
@@ -85,6 +91,9 @@ describe('Output to files.', () => {
         expect(fs.existsSync(actualFile), `Expected output file ${actualFile} to exist.`).to.be.true;
         expectOutFilesMatch(actualFile, specFile);
       });
+
+      const shouldNotExist = glob.sync('./output_nested/**/suiteInOtherFile*', {nodir: true});
+      expect(shouldNotExist, `Expect no output file for suiteInOtherFile to exist.`).to.have.length(0);
     });
   }).timeout(90000);
 


### PR DESCRIPTION
 Fix issue where top-level `.spec` files that call test functions in other files results in multiple output files being created. 

Example of this bug:

Folder structure:
```
cypress/integration
   |
   - common-suite-test.ts
   - /specs
       |
        - test_1.spec.ts
 ```

 common-suite-test.ts:
```
export function runSuite() {
  context('suite title', ()=>{
       it('run the test', ()=>{})
  })
}
```

 test_1.spec.ts
```
import {runSuite} from './common-suite-test'

context('top-level suite', ()=>{
    it('run test in top-level', ()=>{})

    runSuite()
})
```
    
would create an output log file structure of
```
logs
   |
   - common-suite-test.json
   - /specs
       |
        - test_1.spec.json
 ```

After the bug fix, the  `runSuite` tests are in the correct file:
```
logs
   |
   - /specs
       |
        - test_1.spec.json
 ```
