### PR TITLE
#151: Fix typescript declaration for support for both commonjs and esm.

### DIFF
--- a/src/installLogsCollector.d.ts
+++ b/src/installLogsCollector.d.ts
@@ -1,90 +1,93 @@
-export type Severity = '' | 'error' | 'warning';
-export type LogType = 'cons:log' |
-  'cons:info' |
-  'cons:warn' |
-  'cons:error' |
-  'cons:debug' |
-  'cy:log' |
-  'cy:xhr' |
-  'cy:fetch' |
-  'cy:request' |
-  'cy:route' |
-  'cy:intercept' |
-  'cy:command' |
-  'ctr:info';
+declare function installLogsCollector(config?: installLogsCollector.SupportOptions): void;
+declare namespace installLogsCollector {
 
-export interface SupportOptions {
-  /**
-   * What types of logs to collect and print.
-   * By default all types are enabled.
-   * The 'cy:command' is the general type that contain all types of commands that are not specially treated.
-   * @default ['cons:log','cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
-   */
-  collectTypes?: readonly string[];
+  type Severity = '' | 'error' | 'warning';
 
-  /**
-   * Callback to filter logs manually. The type is from the same list as for the collectTypes option.
-   * Severity can be of ['', 'error', 'warning'].
-   * @default undefined
-   */
-  filterLog?:
-    | null
-    | NonNullable<SupportOptions['collectTypes']>[number]
-    | ((args: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity]) => boolean);
+  type LogType = 'cons:log' |
+    'cons:info' |
+    'cons:warn' |
+    'cons:error' |
+    'cons:debug' |
+    'cy:log' |
+    'cy:xhr' |
+    'cy:fetch' |
+    'cy:request' |
+    'cy:route' |
+    'cy:intercept' |
+    'cy:command' |
+    'ctr:info';
 
-  /**
-   * Callback to process logs manually. The type is from the same list as for the collectTypes option.
-   * Severity can be of ['', 'error', 'warning'].
-   * @default undefined
-   */
-  processLog?:
+  interface SupportOptions {
+    /**
+     * What types of logs to collect and print.
+     * By default all types are enabled.
+     * The 'cy:command' is the general type that contain all types of commands that are not specially treated.
+     * @default ['cons:log','cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
+     */
+    collectTypes?: readonly string[];
+
+    /**
+     * Callback to filter logs manually. The type is from the same list as for the collectTypes option.
+     * Severity can be of ['', 'error', 'warning'].
+     * @default undefined
+     */
+    filterLog?:
       | null
       | NonNullable<SupportOptions['collectTypes']>[number]
-      | ((args: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity]) => [LogType, string, Severity]);
-
-  /**
-   * Callback to collect each test case's logs after its run.
-   * @default undefined
-   */
-  collectTestLogs?: (
-    context: {mochaRunnable: any, testState: string, testTitle: string, testLevel: number},
-    messages: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity][]
-  ) => void;
-
-  xhr?: {
-    /**
-     * Whether to print header data for XHR requests.
-     * @default false
-     */
-    printHeaderData?: boolean;
+      | ((args: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity]) => boolean);
 
     /**
-     * Whether to print request data for XHR requests besides response data.
+     * Callback to process logs manually. The type is from the same list as for the collectTypes option.
+     * Severity can be of ['', 'error', 'warning'].
+     * @default undefined
+     */
+    processLog?:
+        | null
+        | NonNullable<SupportOptions['collectTypes']>[number]
+        | ((args: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity]) => [LogType, string, Severity]);
+
+    /**
+     * Callback to collect each test case's logs after its run.
+     * @default undefined
+     */
+    collectTestLogs?: (
+      context: {mochaRunnable: any, testState: string, testTitle: string, testLevel: number},
+      messages: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity][]
+    ) => void;
+
+    xhr?: {
+      /**
+       * Whether to print header data for XHR requests.
+       * @default false
+       */
+      printHeaderData?: boolean;
+
+      /**
+       * Whether to print request data for XHR requests besides response data.
+       * @default false
+       */
+      printRequestData?: boolean;
+    };
+
+    /**
+     * Enables extended log collection: including after all and before all hooks.
+     * @unstable
      * @default false
      */
-    printRequestData?: boolean;
-  };
+    enableExtendedCollector?: boolean;
 
-  /**
-   * Enables extended log collection: including after all and before all hooks.
-   * @unstable
-   * @default false
-   */
-  enableExtendedCollector?: boolean;
+    /**
+     * Enables continuous logging of logs to terminal one by one, as they get registerd or modified.
+     * @unstable
+     * @default false
+     */
+    enableContinuousLogging?: boolean;
 
-  /**
-   * Enables continuous logging of logs to terminal one by one, as they get registerd or modified.
-   * @unstable
-   * @default false
-   */
-  enableContinuousLogging?: boolean;
-
-  /**
-   * Enabled debug logging.
-   * @default false
-   */
-  debug?: boolean;
+    /**
+     * Enabled debug logging.
+     * @default false
+     */
+    debug?: boolean;
+  }
 }
-
-declare function installLogsCollector(config?: SupportOptions): void;
-export default installLogsCollector;
+export = installLogsCollector;


### PR DESCRIPTION
This exports the installLogsCollector function the same way as the installLogsPrinter (see commit https://github.com/archfz/cypress-terminal-report/commit/743b551d3a29d34ac8d256405525152b73b2a2c4)
