### PR TITLE
Add missing property to schema

### DIFF
--- a/src/installLogsCollector.schema.json
+++ b/src/installLogsCollector.schema.json
@@ -17,6 +17,7 @@
           "cons:info",
           "cons:warn",
           "cons:error",
+          "cons:debug",
           "cy:log",
           "cy:xhr",
           "cy:fetch",


### PR DESCRIPTION
This schema update was missing from PR https://github.com/archfz/cypress-terminal-report/pull/48. Validation fails (as do tests) if you add "cons:debug" to option `collectTypes`.