### PR TITLE
Fix xhr and fetch logging in Cypress 13+ to use props sub-key of consoleProps

### DIFF
--- a/src/collector/LogCollectCypressFetch.js
+++ b/src/collector/LogCollectCypressFetch.js
@@ -12,9 +12,12 @@ module.exports = class LogCollectCypressFetch {
   }
 
   register() {
+    // In Cypress 13+ this is under an extra props key
+    const consoleProps = (options) => options.consoleProps && options.consoleProps.props ? options.consoleProps.props : options.consoleProps
+
     const formatFetch = (options) => (options.alias !== undefined ? '(' + options.alias + ') ' : '') +
-      (options.consoleProps["Request went to origin?"] !== 'yes' ? 'STUBBED ' : '') +
-      options.consoleProps.Method + ' ' + options.consoleProps.URL;
+      (consoleProps(options)["Request went to origin?"] !== 'yes' ? 'STUBBED ' : '') +
+      consoleProps(options).Method + ' ' + consoleProps(options).URL;
 
     const formatDuration = (durationInMs) =>
       durationInMs < 1000 ? `${durationInMs} ms` : `${durationInMs / 1000} s`;
@@ -34,14 +37,14 @@ module.exports = class LogCollectCypressFetch {
       ) {
         let statusCode;
 
-        statusCode = options.consoleProps["Response Status Code"];
+        statusCode = consoleProps(options)["Response Status Code"];
 
         const isSuccess = statusCode && (statusCode + '')[0] === '2';
         const severity = isSuccess ? CONSTANTS.SEVERITY.SUCCESS : CONSTANTS.SEVERITY.WARNING;
         let log = formatFetch(options);
 
-        if (options.consoleProps.Duration) {
-          log += ` (${formatDuration(options.consoleProps.Duration)})`;
+        if (consoleProps(options).Duration) {
+          log += ` (${formatDuration(consoleProps(options).Duration)})`;
         }
         if (statusCode) {
           log += `\nStatus: ${statusCode}`;
@@ -52,9 +55,9 @@ module.exports = class LogCollectCypressFetch {
 
         if (
           !isSuccess &&
-          options.consoleProps["Response Body"]
+          consoleProps(options)["Response Body"]
         ) {
-          log += `\nResponse body: ${await this.format.formatXhrBody(options.consoleProps["Response Body"])}`;
+          log += `\nResponse body: ${await this.format.formatXhrBody(consoleProps(options)["Response Body"])}`;
         }
 
         this.collectorState.updateLog(log, severity, options.id);

--- a/src/collector/LogCollectCypressXhr.js
+++ b/src/collector/LogCollectCypressXhr.js
@@ -12,9 +12,12 @@ module.exports = class LogCollectCypressXhr {
   }
 
   register() {
-    const formatXhr = (options) =>
-      (options.renderProps.wentToOrigin ? '' : 'STUBBED ') +
-      options.consoleProps.Method + ' ' + options.consoleProps.URL;
+    // In Cypress 13+ this is under an extra props key
+    const consoleProps = (options) => options.consoleProps && options.consoleProps.props ? options.consoleProps.props : options.consoleProps
+
+    const formatXhr = (options) => (options.alias !== undefined ? '(' + options.alias + ') ' : '') +
+      (consoleProps(options)["Request went to origin?"] !== 'yes' ? 'STUBBED ' : '') +
+      consoleProps(options).Method + ' ' + consoleProps(options).URL;
 
     const formatDuration = (durationInMs) =>
       durationInMs < 1000 ? `${durationInMs} ms` : `${durationInMs / 1000} s`;
@@ -22,7 +25,7 @@ module.exports = class LogCollectCypressXhr {
     Cypress.on('log:added', (options) => {
       if (
         options.instrument === 'command' &&
-        options.consoleProps &&
+        consoleProps(options) &&
         options.displayName === 'xhr'
       ) {
         const log = formatXhr(options);
@@ -35,13 +38,13 @@ module.exports = class LogCollectCypressXhr {
       if (
         options.instrument === 'command' &&
         ['request', 'xhr'].includes(options.name) &&
-        options.consoleProps &&
+        consoleProps(options) &&
         options.state !== 'pending'
       ) {
         let statusCode;
 
-        if (options.consoleProps['Response Status Code']) {
-          statusCode = options.consoleProps['Response Status Code'];
+        if (consoleProps(options)['Response Status Code']) {
+          statusCode = consoleProps(options)['Response Status Code'];
         }
 
         const isSuccess = statusCode && (statusCode + '')[0] === '2';
@@ -49,8 +52,8 @@ module.exports = class LogCollectCypressXhr {
         let log = formatXhr(options);
 
         // @TODO: Not supported anymore :(
-        if (options.consoleProps.Duration) {
-          log += ` (${formatDuration(options.consoleProps.Duration)})`;
+        if (consoleProps(options).Duration) {
+          log += ` (${formatDuration(consoleProps(options).Duration)})`;
         }
         if (statusCode) {
           log += `\nStatus: ${statusCode}`;
@@ -60,27 +63,27 @@ module.exports = class LogCollectCypressXhr {
         }
         if (
           this.config.collectRequestData && this.config.collectHeaderData &&
-          options.consoleProps['Request Headers']
+          consoleProps(options)['Request Headers']
         ) {
-          log += `\nRequest headers: ${await this.format.formatXhrBody(options.consoleProps['Request Headers'])}`;
+          log += `\nRequest headers: ${await this.format.formatXhrBody(consoleProps(options)['Request Headers'])}`;
         }
         if (
           this.config.collectRequestData &&
-          options.consoleProps['Request Body']
+          consoleProps(options)['Request Body']
         ) {
-          log += `\nRequest body: ${await this.format.formatXhrBody(options.consoleProps['Request Body'])}`;
+          log += `\nRequest body: ${await this.format.formatXhrBody(consoleProps(options)['Request Body'])}`;
         }
         if (
           this.config.collectHeaderData &&
-          options.consoleProps['Response Headers']
+          consoleProps(options)['Response Headers']
         ) {
-          log += `\nResponse headers: ${await this.format.formatXhrBody(options.consoleProps['Response Headers'])}`;
+          log += `\nResponse headers: ${await this.format.formatXhrBody(consoleProps(options)['Response Headers'])}`;
         }
         if (
           !isSuccess &&
-          options.consoleProps['Response Body']
+          consoleProps(options)['Response Body']
         ) {
-          log += `\nResponse body: ${await this.format.formatXhrBody(options.consoleProps['Response Body'])}`;
+          log += `\nResponse body: ${await this.format.formatXhrBody(consoleProps(options)['Response Body'])}`;
         }
 
         this.collectorState.updateLog(log, severity, options.id);

--- a/src/collector/LogCollectCypressXhr.js
+++ b/src/collector/LogCollectCypressXhr.js
@@ -16,7 +16,7 @@ module.exports = class LogCollectCypressXhr {
     const consoleProps = (options) => options.consoleProps && options.consoleProps.props ? options.consoleProps.props : options.consoleProps
 
     const formatXhr = (options) => (options.alias !== undefined ? '(' + options.alias + ') ' : '') +
-      (consoleProps(options)["Request went to origin?"] !== 'yes' ? 'STUBBED ' : '') +
+      (options.renderProps.wentToOrigin ? '' : 'STUBBED ') +
       consoleProps(options).Method + ' ' + consoleProps(options).URL;
 
     const formatDuration = (durationInMs) =>

--- a/src/collector/LogCollectCypressXhr.js
+++ b/src/collector/LogCollectCypressXhr.js
@@ -15,7 +15,7 @@ module.exports = class LogCollectCypressXhr {
     // In Cypress 13+ this is under an extra props key
     const consoleProps = (options) => options.consoleProps && options.consoleProps.props ? options.consoleProps.props : options.consoleProps
 
-    const formatXhr = (options) => (options.alias !== undefined ? '(' + options.alias + ') ' : '') +
+    const formatXhr = (options) =>
       (options.renderProps.wentToOrigin ? '' : 'STUBBED ') +
       consoleProps(options).Method + ' ' + consoleProps(options).URL;
 


### PR DESCRIPTION
Fixes #209

Supports both Cypress <12 and Cypress 13+ format for `consoleProps` for xhr and fetch logs.