### PR TITLE
typescript: LogType and Severity to enums

### DIFF
--- a/src/installLogsCollector.d.ts
+++ b/src/installLogsCollector.d.ts
@@ -28,7 +28,7 @@ declare namespace installLogsCollector {
      * What types of logs to collect and print.
      * By default all types are enabled.
      * The 'cy:command' is the general type that contain all types of commands that are not specially treated.
-     * @default ['cons:log', 'cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
+     * @default ['cons:log', 'cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:intercept', 'cy:command']
      */
     collectTypes?: readonly LogType[];
 

--- a/src/installLogsCollector.d.ts
+++ b/src/installLogsCollector.d.ts
@@ -1,30 +1,36 @@
 declare function installLogsCollector(config?: installLogsCollector.SupportOptions): void;
 declare namespace installLogsCollector {
-  type Severity = '' | 'error' | 'warning';
+  enum Severity {
+    NONE = '',
+    ERROR = 'error',
+    WARNING = 'warning'
+  }
 
-  type LogType = 'cons:log' |
-    'cons:info' |
-    'cons:warn' |
-    'cons:error' |
-    'cons:debug' |
-    'cy:log' |
-    'cy:xhr' |
-    'cy:fetch' |
-    'cy:request' |
-    'cy:intercept' |
-    'cy:command' |
-    'ctr:info';
+  enum LogType {
+    CONSOLE_LOG = 'cons:log',
+    CONSOLE_INFO = 'cons:info',
+    CONSOLE_WARN = 'cons:warn',
+    CONSOLE_ERROR = 'cons:error',
+    CONSOLE_DEBUG = 'cons:debug',
+    CY_LOG = 'cy:log',
+    CY_XHR = 'cy:xhr',
+    CY_FETCH = 'cy:fetch',
+    CY_REQUEST = 'cy:request' ,
+    CY_INTERCEPT = 'cy:intercept',
+    CY_COMMAND = 'cy:command',
+    CTR_INFO = 'ctr:info'
+  }
 
-  type Log = [/* type: */ LogType, /* message: */ string, /* severity: */ Severity];
+  type Log = [type: LogType, message: string, severity: Severity];
 
   interface SupportOptions {
     /**
      * What types of logs to collect and print.
      * By default all types are enabled.
      * The 'cy:command' is the general type that contain all types of commands that are not specially treated.
-     * @default ['cons:log','cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
+     * @default ['cons:log', 'cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
      */
-    collectTypes?: readonly string[];
+    collectTypes?: readonly LogType[];
 
     /**
      * Callback to filter logs manually. The type is from the same list as for the collectTypes option.

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -2,21 +2,26 @@
 
 declare function installLogsPrinter(on: Cypress.PluginEvents, options?: installLogsPrinter.PluginOptions): void;
 declare namespace installLogsPrinter {
+  enum Severity {
+    NONE = '',
+    ERROR = 'error',
+    WARNING = 'warning'
+  }
 
-  type Severity = '' | 'error' | 'warning';
-
-  type LogType = 'cons:log' |
-    'cons:info' |
-    'cons:warn' |
-    'cons:error' |
-    'cons:debug' |
-    'cy:log' |
-    'cy:xhr' |
-    'cy:fetch' |
-    'cy:request' |
-    'cy:intercept' |
-    'cy:command' |
-    'ctr:info';
+  enum LogType {
+    CONSOLE_LOG = 'cons:log',
+    CONSOLE_INFO = 'cons:info',
+    CONSOLE_WARN = 'cons:warn',
+    CONSOLE_ERROR = 'cons:error',
+    CONSOLE_DEBUG = 'cons:debug',
+    CY_LOG = 'cy:log',
+    CY_XHR = 'cy:xhr',
+    CY_FETCH = 'cy:fetch',
+    CY_REQUEST = 'cy:request' ,
+    CY_INTERCEPT = 'cy:intercept',
+    CY_COMMAND = 'cy:command',
+    CTR_INFO = 'ctr:info'
+  }
 
   type AllMessages = {
     [specPath: string]: {
@@ -114,7 +119,7 @@ declare namespace installLogsPrinter {
      * Callback to collect each test case's logs after its run.
      * @default undefined
      */
-    collectTestLogs?: (context: {spec: string, test: string, state: string}, messages: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity][]) => void;
+    collectTestLogs?: (context: {spec: string, test: string, state: string}, messages: [type: LogType, message: string, severity: Severity][]) => void;
   }
 }
 export = installLogsPrinter;


### PR DESCRIPTION
Use enums instead of string unions. More useful for consumers.