### PR TITLE
feat(TS): more Output Processor type declarations

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,11 +306,12 @@ Inside the function you will have access to the following API:
 
 - `this.size` - Current char size of the output file.
 - `this.atChunk` - The count of the chunk to be written.
-- `this.initialContent` - The initial content of the file. Defaults to ''. Set this
+- `this.initialContent` - The initial content of the file. Defaults to `''`. Set this
 before the first chunk write in order for it to work.
-- `this.chunkSeparator` - Chunk separator string. Defaults to ''. This string will 
+- `this.chunkSeparator` - Chunk separator string. Defaults to `''`. This string will 
 be written between each chunk. If you need a special separator between chunks use this 
 as it is internally handled to properly write and replace the chunks.
+- `this.initialize()` - Unlinks file to initialize. This is required for custom output processors provided as config to be able to define custom initial content.
 - `this.writeSpecChunk(specPath, dataString, positionInFile?)` - Writes a chunk of 
 data in the output file.
 

--- a/README.md
+++ b/README.md
@@ -311,7 +311,6 @@ before the first chunk write in order for it to work.
 - `this.chunkSeparator` - Chunk separator string. Defaults to `''`. This string will 
 be written between each chunk. If you need a special separator between chunks use this 
 as it is internally handled to properly write and replace the chunks.
-- `this.initialize()` - Unlinks file to initialize. This is required for custom output processors provided as config to be able to define custom initial content.
 - `this.writeSpecChunk(specPath, dataString, positionInFile?)` - Writes a chunk of 
 data in the output file.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
-declare namespace Cypress {
-  // @ts-ignore
-  import type {Log} from "./src/installLogsCollector";
 
+import type { Log } from "./src/installLogsCollector";
+
+declare namespace Cypress {
   interface Cypress {
     TerminalReport: {
       getLogs<T extends 'txt' | 'json' | 'none' = 'none'>(format?: T): {

--- a/src/installLogsCollector.d.ts
+++ b/src/installLogsCollector.d.ts
@@ -15,16 +15,16 @@ declare namespace installLogsCollector {
     'cy:command' |
     'ctr:info';
 
-  type Log = [/* type: */ LogType, /* message: */ string, /* severity: */ Severity];
+  type Log = [type: LogType, message: string, severity: Severity];
 
   interface SupportOptions {
     /**
      * What types of logs to collect and print.
      * By default all types are enabled.
      * The 'cy:command' is the general type that contain all types of commands that are not specially treated.
-     * @default ['cons:log','cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:route', 'cy:command']
+     * @default ['cons:log', 'cons:info', 'cons:warn', 'cons:error', 'cy:log', 'cy:xhr', 'cy:fetch', 'cy:request', 'cy:intercept', 'cy:command']
      */
-    collectTypes?: readonly string[];
+    collectTypes?: readonly LogType[];
 
     /**
      * Callback to filter logs manually. The type is from the same list as for the collectTypes option.

--- a/src/installLogsCollector.js
+++ b/src/installLogsCollector.js
@@ -25,6 +25,7 @@ const logsTxtFormatter = require("./outputProcessor/logsTxtFormatter");
  * Needs to be added to support file.
  *
  * @see ./installLogsCollector.d.ts
+ * @type {import('./installLogsCollector')} 
  */
 function installLogsCollector(config = {}) {
   validateConfig(config);

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -26,31 +26,34 @@ declare namespace installLogsPrinter {
 
   interface PluginOptions {
     /**
-     * Max length of cy.log and console.warn/console.error.
+     * Max length of `cy.log` and `console.warn`/`console.error`.
      * @default 800
      */
     defaultTrimLength?: number;
 
     /**
-     * Max length of cy commands.
+     * Max length of `cy` commands.
      * @default 800
      */
     commandTrimLength?: number;
 
     /**
-     * Max length of cy.route request data.
+     * Max length of `cy.route` request data.
      * @default 5000
      */
     routeTrimLength?: number;
 
     /**
-     * If it is set to a number greater or equal to 0, this amount of logs will be printed only around failing commands. Use this to have shorter output especially for when there are a lot of commands in tests. When used with options.printLogs=always for tests that don't have any severity=error logs nothing will be printed.
+     * If set to a number greater or equal to 0, this amount of logs will be printed only around failing commands. 
+     * Use this to have shorter output especially for when there are a lot of commands in tests.
+     * When used with `options.printLogs=always`, for tests that don't have any `severity=error` logs, nothing will be printed.
      * @default null
      */
     compactLogs?: number | null;
 
     /**
-     * If it is set to a number greater or equal to 0, will override compactLogs for the file log output specifically. Use this for compacting of the terminal and the file output logs to different levels.
+     * If it is set to a number greater or equal to 0, will override `compactLogs` for the file log output specifically.
+     * Use this for compacting of the terminal and the file output logs to different levels.
      * @default null
      */
     outputCompactLogs?: false | number | null;
@@ -105,7 +108,7 @@ declare namespace installLogsPrinter {
     includeSuccessfulHookLogs?: boolean;
 
     /**
-     * When set to true it enables additional log write pass to files
+     * When set to `true`, enables additional log write pass to files.
      * @default false
      */
     logToFilesOnAfterRun?: boolean;

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="cypress" />
-import { Log } from "./installLogsCollector";
+import type { Log } from "./installLogsCollector";
+import type CustomOutputProcessor from "./outputProcessor/CustomOutputProcessor";
 
 declare function installLogsPrinter(on: Cypress.PluginEvents, options?: installLogsPrinter.PluginOptions): void;
 declare namespace installLogsPrinter {
@@ -23,6 +24,8 @@ declare namespace installLogsPrinter {
       [testTitle: string]: Log[]
     }
   };
+
+  type CustomOutputProcessorCallback = ((this: CustomOutputProcessor, allMessages: AllMessages) => void);
 
   interface PluginOptions {
     /**
@@ -72,7 +75,7 @@ declare namespace installLogsPrinter {
       string,
       | 'json'
       | 'txt'
-      | ((allMessages: AllMessages) => void)
+      | CustomOutputProcessorCallback
       >;
 
     /**

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -1,8 +1,8 @@
 /// <reference types="cypress" />
+import { Log } from "./installLogsCollector";
 
 declare function installLogsPrinter(on: Cypress.PluginEvents, options?: installLogsPrinter.PluginOptions): void;
 declare namespace installLogsPrinter {
-
   type Severity = '' | 'error' | 'warning';
 
   type LogType = 'cons:log' |
@@ -20,7 +20,7 @@ declare namespace installLogsPrinter {
 
   type AllMessages = {
     [specPath: string]: {
-      [testTitle: string]: [type: LogType, message: string, severity: Severity][]
+      [testTitle: string]: Log[]
     }
   };
 
@@ -114,7 +114,7 @@ declare namespace installLogsPrinter {
      * Callback to collect each test case's logs after its run.
      * @default undefined
      */
-    collectTestLogs?: (context: {spec: string, test: string, state: string}, messages: [/* type: */ LogType, /* message: */ string, /* severity: */ Severity][]) => void;
+    collectTestLogs?: (context: {spec: string, test: string, state: string}, messages: Log[]) => void;
   }
 }
 export = installLogsPrinter;

--- a/src/installLogsPrinter.d.ts
+++ b/src/installLogsPrinter.d.ts
@@ -25,7 +25,7 @@ declare namespace installLogsPrinter {
     }
   };
 
-  type CustomOutputProcessorCallback = ((this: CustomOutputProcessor, allMessages: AllMessages) => void);
+  type CustomOutputProcessorCallback = (this: CustomOutputProcessor, allMessages: AllMessages) => void;
 
   interface PluginOptions {
     /**

--- a/src/installLogsPrinter.js
+++ b/src/installLogsPrinter.js
@@ -1,3 +1,16 @@
+/**
+ * @typedef {import('./installLogsCollector').Log} Log 
+ * @typedef {import('./installLogsPrinter').PluginOptions} PluginOptions
+ * @typedef {{ messages: Log[], 
+ *             isHook: boolean, 
+ *             state: string, 
+ *             spec: string, 
+ *             test: string, 
+ *             level?: number,
+ *             consoleTitle?: string,
+ *             continuous?: boolean }} Data
+ */
+
 const chalk = require('chalk');
 const path = require('path');
 const tv4 = require('tv4');
@@ -46,6 +59,7 @@ let outputProcessors = [];
  * Needs to be added to plugins file.
  *
  * @see ./installLogsPrinter.d.ts
+ * @type {import('./installLogsPrinter')}
  */
 function installLogsPrinter(on, options = {}) {
   options.printLogsToFile = options.printLogsToFile || "onFail";
@@ -57,7 +71,7 @@ function installLogsPrinter(on, options = {}) {
   }
 
   on('task', {
-    [CONSTANTS.TASK_NAME]: function (data) {
+    [CONSTANTS.TASK_NAME]: function (/** @type {Data} */ data) {
       let messages = data.messages;
 
       const terminalMessages =
@@ -118,13 +132,13 @@ function installLogsPrinter(on, options = {}) {
   }
 }
 
-function enableLogToFilesOnAfterRun(on, options) {
+function enableLogToFilesOnAfterRun(on, /** @type {PluginOptions} */ options) {
   on('after:run', () => {
     logToFiles(options);
   });
 }
 
-function logToFiles(options) {
+function logToFiles(/** @type {PluginOptions} */ options) {
   outputProcessors.forEach((processor) => {
     if (Object.entries(writeToFileMessages).length !== 0){
       processor.write(writeToFileMessages);
@@ -148,8 +162,7 @@ function logOutputTarget(processor) {
   }
   console.log('cypress-terminal-report:', message);
 }
-
-function installOutputProcessors(on, options) {
+function installOutputProcessors(on, /** @type {PluginOptions} */ options) {
   if (!options.outputRoot) {
     throw new CtrError(`Missing outputRoot configuration.`);
   }
@@ -189,7 +202,11 @@ function installOutputProcessors(on, options) {
   outputProcessors.forEach((processor) => processor.initialize());
 }
 
-function compactLogs(logs, keepAroundCount) {
+function compactLogs(
+  /** @type {Log[]} */ 
+  logs, 
+  /** @type {number} */ 
+  keepAroundCount) {
   const failingIndexes = logs.filter((log) => log[2] === CONSTANTS.SEVERITY.ERROR)
     .map((log) => logs.indexOf(log));
 
@@ -232,7 +249,13 @@ function compactLogs(logs, keepAroundCount) {
   return compactedLogs;
 }
 
-function logToTerminal(messages, options, data) {
+function logToTerminal(
+  /** @type {Log[]} */
+  messages, 
+  /** @type {PluginOptions} */
+  options,
+  /** @type {Data} */
+  data) {
   const tabLevel = data.level || 0;
   const levelPadding = '  '.repeat(Math.max(0, tabLevel - 1));
   const padding = CONSTANTS.PADDING.LOG + levelPadding;

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -22,7 +22,23 @@ export class BaseOutputProcessor {
   initialContent: string;
   chunkSeparator: string;
 
+  /**
+   * @returns `this.file`
+   */
+  getTarget(): string;
+  /**
+   * Unlink file on initialize to start clean.
+   * This is required for custom output processors provided as config to be able to define custom initial content.
+   */
+  initialize(): void;
+  prepareForWrite(): void;
   writeSpecChunk(spec: string, chunk: string, pos?: number): void;
+  replaceSpecChunk(spec: string, chunk: string): void;
+  appendSeparator(pos: number): void;
+  /**
+   * @returns data buffer length
+   */
+  writeAtPosition(data: string, pos: number): number;
 }
 
 

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -5,7 +5,7 @@
  * @example
  * ```
  * import { type AllMessages } from 'cypress-terminal-report/src/installLogsPrinter'
- * import { type BaseOutputProcessor } from 'cypress-terminal-report/src/outputProcessor/BaseOutputProcessor'
+ * import type BaseOutputProcessor from 'cypress-terminal-report/src/outputProcessor/BaseOutputProcessor'
  * 
  * ...
  *
@@ -14,32 +14,38 @@
  * }
  * ```
  */
-export class BaseOutputProcessor {
+ declare class BaseOutputProcessor {
   constructor(file: string);
 
+  /**
+   * Current char size of the output file.
+   */
   size: number;
+  /**
+   * The count of the chunk to be written.
+   */
   atChunk: number;
+  /**
+   * The initial content of the file. Defaults to `''`. Set this before the first chunk write in order for it to work.
+   */
   initialContent: string;
+  /**
+   * Chunk separator string. Defaults to `''`. This string will be written between each chunk.
+   * If you need a special separator between chunks, use this as it is internally handled to properly write and replace the chunks.
+   */
   chunkSeparator: string;
 
   /**
-   * @returns `this.file`
-   */
-  getTarget(): string;
-  /**
-   * Unlink file on initialize to start clean.
-   * This is required for custom output processors provided as config to be able to define custom initial content.
+   * Unlinks file to initialize. This is required for custom output processors provided as config to be able to define custom initial content.
    */
   initialize(): void;
-  prepareForWrite(): void;
-  writeSpecChunk(spec: string, chunk: string, pos?: number): void;
-  replaceSpecChunk(spec: string, chunk: string): void;
-  appendSeparator(pos: number): void;
   /**
-   * @returns data buffer length
+   * Writes a chunk of data in the output file.
    */
-  writeAtPosition(data: string, pos: number): number;
+  writeSpecChunk(spec: string, chunk: string, pos?: number): void;
 }
+
+export = BaseOutputProcessor;
 
 
 

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -25,7 +25,7 @@ declare class BaseOutputProcessor {
   /**
    * Writes a chunk of data in the output file.
    */
-  writeSpecChunk(spec: string, chunk: string, pos?: number): void;
+  writeSpecChunk(spec: string, chunk: string, pos?: number | null): void;
 }
 
 export = BaseOutputProcessor;

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -1,18 +1,18 @@
 /**
  * Gives the functions and variables available for use when specifying a custom output processor.
- * i.e. Allows use of this.writeSpecChunk without ts warning/error
+ * i.e. Allows use of `this.writeSpecChunk` without ts warning/error.
  * 
- * Example usage:
- * 
- * import { AllMessages } from 'cypress-terminal-report/src/installLogsPrinter'
- * import { BaseOutputProcessor } from 'cypress-terminal-report/src/outputProcessor/BaseOutputProcessor'
+ * @example
+ * ```
+ * import { type AllMessages } from 'cypress-terminal-report/src/installLogsPrinter'
+ * import { type BaseOutputProcessor } from 'cypress-terminal-report/src/outputProcessor/BaseOutputProcessor'
  * 
  * ...
- * 
+ *
  * outputTarget: {
- *     'custom|cts':  function outputProcessor(this: BaseOutputProcessor, messages: AllMessages){ <custom output processor function> }                
- * },
- * 
+ *     'custom|cts': function outputProcessor(this: BaseOutputProcessor, messages: AllMessages){ <custom output processor function> }                
+ * }
+ * ```
  */
 export class BaseOutputProcessor {
   constructor(file: string);

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -1,5 +1,5 @@
 /**
- * Base output processor class that the main processors extend.
+ * Base output processor class that the actual output processors extend.
  */
 declare class BaseOutputProcessor {
   constructor(file: string);

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -1,18 +1,5 @@
 /**
- * Gives the functions and variables available for use when specifying a custom output processor.
- * i.e. Allows use of `this.writeSpecChunk` without ts warning/error.
- * 
- * @example
- * ```
- * import { type AllMessages } from 'cypress-terminal-report/src/installLogsPrinter'
- * import type BaseOutputProcessor from 'cypress-terminal-report/src/outputProcessor/BaseOutputProcessor'
- * 
- * ...
- *
- * outputTarget: {
- *     'custom|cts': function outputProcessor(this: BaseOutputProcessor, messages: AllMessages){ <custom output processor function> }                
- * }
- * ```
+ * Base output processor class that the main processors extend.
  */
  declare class BaseOutputProcessor {
   constructor(file: string);
@@ -35,10 +22,6 @@
    */
   chunkSeparator: string;
 
-  /**
-   * Unlinks file to initialize. This is required for custom output processors provided as config to be able to define custom initial content.
-   */
-  initialize(): void;
   /**
    * Writes a chunk of data in the output file.
    */

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -1,7 +1,7 @@
 /**
  * Base output processor class that the main processors extend.
  */
- declare class BaseOutputProcessor {
+declare class BaseOutputProcessor {
   constructor(file: string);
 
   /**

--- a/src/outputProcessor/BaseOutputProcessor.d.ts
+++ b/src/outputProcessor/BaseOutputProcessor.d.ts
@@ -29,6 +29,3 @@ declare class BaseOutputProcessor {
 }
 
 export = BaseOutputProcessor;
-
-
-

--- a/src/outputProcessor/BaseOutputProcessor.js
+++ b/src/outputProcessor/BaseOutputProcessor.js
@@ -42,6 +42,7 @@ module.exports = class BaseOutputProcessor {
     fs.writeFileSync(this.file, this.initialContent);
   }
 
+  /** @type { import('./BaseOutputProcessor')['writeSpecChunk']} */
   writeSpecChunk(spec, chunk, pos = null) {
     const startTime = new Date().getTime();
 

--- a/src/outputProcessor/CustomOutputProcessor.d.ts
+++ b/src/outputProcessor/CustomOutputProcessor.d.ts
@@ -1,29 +1,25 @@
-import { AllMessages } from "../installLogsPrinter";
-import BaseOutputProcessor  from "./BaseOutputProcessor";
+import type { CustomOutputProcessorCallback } from "../installLogsPrinter";
+import type BaseOutputProcessor  from "./BaseOutputProcessor";
 
 /**
- * Custom output processor. [More details](https://github.com/archfz/cypress-terminal-report#custom-output-log-processor).
+ * Gives the functions and variables available for use when specifying a custom output processor. [More details](https://github.com/archfz/cypress-terminal-report#custom-output-log-processor).
+ * 
+ * i.e. Allows use of `this.writeSpecChunk` without ts warning/error.
  * 
  * @example
  * ```
- * import CustomOutputProcessor from 'cypress-terminal-report/src/outputProcessor/CustomOutputProcessor'
+ * import type { AllMessages } from 'cypress-terminal-report/src/installLogsPrinter'
+ * import type CustomOutputProcessor from 'cypress-terminal-report/src/outputProcessor/CustomOutputProcessor'
+ * 
+ * ...
  *
- * const processor = new CustomOutputProcessor('output.html', 
- *     function outputProcessor(this: BaseOutputProcessor, messages: AllMessages){ 
- *         <custom output processor function> 
- *     }
- * )
- * processor.initialize()
- * processor.write( <all messages> )
+ * outputTarget: {
+ *     'custom|cts': function outputProcessor(this: CustomOutputProcessor, allMessages: AllMessages){ <custom output processor function> }                
+ * }
  * ```
  */
 declare class CustomOutputProcessor extends BaseOutputProcessor {
-    constructor(file: string, processorCallback: ((allMessages: AllMessages) => void));
-
-    /**
-     * Calls `this.processorCallback`
-     */
-    write(allMessages: AllMessages): void;
+    constructor(file: string, processorCallback: CustomOutputProcessorCallback);
 }  
 
 export = CustomOutputProcessor;

--- a/src/outputProcessor/CustomOutputProcessor.d.ts
+++ b/src/outputProcessor/CustomOutputProcessor.d.ts
@@ -23,6 +23,3 @@ declare class CustomOutputProcessor extends BaseOutputProcessor {
 }  
 
 export = CustomOutputProcessor;
-  
-  
-  

--- a/src/outputProcessor/CustomOutputProcessor.d.ts
+++ b/src/outputProcessor/CustomOutputProcessor.d.ts
@@ -1,0 +1,32 @@
+import { AllMessages } from "../installLogsPrinter";
+import BaseOutputProcessor  from "./BaseOutputProcessor";
+
+/**
+ * Custom output processor. [More details](https://github.com/archfz/cypress-terminal-report#custom-output-log-processor).
+ * 
+ * @example
+ * ```
+ * import CustomOutputProcessor from 'cypress-terminal-report/src/outputProcessor/CustomOutputProcessor'
+ *
+ * const processor = new CustomOutputProcessor('output.html', 
+ *     function outputProcessor(this: BaseOutputProcessor, messages: AllMessages){ 
+ *         <custom output processor function> 
+ *     }
+ * )
+ * processor.initialize()
+ * processor.write( <all messages> )
+ * ```
+ */
+declare class CustomOutputProcessor extends BaseOutputProcessor {
+    constructor(file: string, processorCallback: ((allMessages: AllMessages) => void));
+
+    /**
+     * Calls `this.processorCallback`
+     */
+    write(allMessages: AllMessages): void;
+}  
+
+export = CustomOutputProcessor;
+  
+  
+  

--- a/src/outputProcessor/CustomOutputProcessor.js
+++ b/src/outputProcessor/CustomOutputProcessor.js
@@ -2,12 +2,14 @@ const BaseOutputProcessor = require('./BaseOutputProcessor');
 
 module.exports = class CustomOutputProcessor extends BaseOutputProcessor {
 
-  constructor(file, processorCallback) {
+  constructor(file, 
+    /** @type {import('../installLogsPrinter').CustomOutputProcessorCallback} */  
+    processorCallback) {
     super(file);
     this.processorCallback = processorCallback;
   }
 
-  write(allMessages) {
+  write(/** @type {import('../installLogsPrinter').AllMessages} */ allMessages) {
     this.processorCallback.call(this, allMessages);
   }
 

--- a/src/outputProcessor/JsonOutputProcessor.d.ts
+++ b/src/outputProcessor/JsonOutputProcessor.d.ts
@@ -1,4 +1,4 @@
-import BaseOutputProcessor from "./BaseOutputProcessor";
+import type BaseOutputProcessor from "./BaseOutputProcessor";
 
 declare class JsonOutputProcessor extends BaseOutputProcessor {}  
 

--- a/src/outputProcessor/JsonOutputProcessor.d.ts
+++ b/src/outputProcessor/JsonOutputProcessor.d.ts
@@ -1,0 +1,6 @@
+import BaseOutputProcessor from "./BaseOutputProcessor";
+
+declare class JsonOutputProcessor extends BaseOutputProcessor {}  
+
+export = JsonOutputProcessor;
+  

--- a/src/outputProcessor/JsonOutputProcessor.js
+++ b/src/outputProcessor/JsonOutputProcessor.js
@@ -8,7 +8,7 @@ module.exports = class JsonOutputProcessor extends BaseOutputProcessor {
     this.chunkSeparator = ',\n';
   }
 
-  write(allMessages) {
+  write(/** @type {import('../installLogsPrinter').AllMessages} */ allMessages) {
     Object.entries(allMessages).forEach(([spec, tests]) => {
       let data = {[spec]: {}};
 

--- a/src/outputProcessor/NestedOutputProcessorDecorator.js
+++ b/src/outputProcessor/NestedOutputProcessorDecorator.js
@@ -30,7 +30,7 @@ module.exports = class NestedOutputProcessorDecorator {
     return processor;
   }
 
-  write(allMessages) {
+  write(/** @type {import('../installLogsPrinter').AllMessages} */ allMessages) {
     Object.entries(allMessages).forEach(([spec, messages]) => {
       this.getProcessor(spec).write({[spec]: messages});
     });

--- a/src/outputProcessor/TextOutputProcessor.d.ts
+++ b/src/outputProcessor/TextOutputProcessor.d.ts
@@ -1,4 +1,4 @@
-import BaseOutputProcessor from "./BaseOutputProcessor";
+import type BaseOutputProcessor from "./BaseOutputProcessor";
 
 declare class TextOutputProcessor extends BaseOutputProcessor {} 
 

--- a/src/outputProcessor/TextOutputProcessor.d.ts
+++ b/src/outputProcessor/TextOutputProcessor.d.ts
@@ -1,0 +1,6 @@
+import BaseOutputProcessor from "./BaseOutputProcessor";
+
+declare class TextOutputProcessor extends BaseOutputProcessor {} 
+
+export = TextOutputProcessor;
+  

--- a/src/outputProcessor/TextOutputProcessor.js
+++ b/src/outputProcessor/TextOutputProcessor.js
@@ -11,8 +11,7 @@ module.exports = class TextOutputProcessor extends BaseOutputProcessor {
     this.chunkSeparator = EOL + EOL;
   }
 
-  write(allMessages) {
-
+  write(/** @type {import('../installLogsPrinter').AllMessages} */ allMessages) {
     Object.entries(allMessages).forEach(([spec, tests]) => {
       let text = `${spec}:${EOL}`;
       Object.entries(tests).forEach(([test, messages]) => {


### PR DESCRIPTION
- Add `.d.ts` type declaration files for the following:
    - `CustomOutputProcessor`
    - `JsonOutputProcessor`
    - `TextOutputProcessor`
- Improve type for custom output processor callback (`CustomOutputProcessorCallback`). [Comment](https://github.com/archfz/cypress-terminal-report/pull/228#discussion_r1424513321)
- Add some JSdoc type hinting to JS files
- Use `Log` type where applicable
- Improve JsDocs