### PR TITLE
#207: Add timestamp to txt output

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ directory. You should add `it.only` to the test case you are working on to speed
 #### 6.0.0
 
 - Add new option [`commandTimings`](#optionscommandtimings) to display the time of the logs. [issue](https://github.com/archfz/cypress-terminal-report/issues/207)
-- ! Breaking change: Refactored the log type: `[type, message, severity]` is now `{type, severity, message}`.
+- ! Breaking change: Refactored the log type: `[type, message, severity]` is now `{type, message, severity}`.
   - If you have used any of the following options, you will have to make changes in the integration:
     `collectTestLogs`, `filterLog`, `processLog`, custom file output processor.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-terminal-report",
-  "version": "5.3.8",
+  "version": "6.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-terminal-report",
-      "version": "5.3.8",
+      "version": "6.0.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0",

--- a/src/outputProcessor/logsTxtFormatter.js
+++ b/src/outputProcessor/logsTxtFormatter.js
@@ -8,14 +8,22 @@ const padTypeText = (text) => {
     + text;
 }
 
+const padTimeText = (text) => {
+  return PADDING_LOGS + text;
+}
+
 function logsTxtFormatter(logs, EOL = '\n') {
-  return logs.map(({type, message, severity}) => {
-    return (padTypeText(`${type} (${{
+  return logs.map(({type, message, severity, timeString}) => {
+    let formattedLog = (padTypeText(`${type} (${{
         [CONSTANTS.SEVERITY.ERROR]: 'X',
         [CONSTANTS.SEVERITY.WARNING]: '!',
         [CONSTANTS.SEVERITY.SUCCESS]: 'K',
       }[severity]}): `) +
       message.replace(/\n/g, `${EOL}${PADDING_LOGS}`) + EOL).replace(/\s+\n/, '\n');
+    if (timeString) {
+      formattedLog = padTimeText(`Time: ${timeString}`) + `\n` + formattedLog;
+    }
+    return formattedLog;
   }).join('');
 }
 


### PR DESCRIPTION
Hello,

This is my attempt at adding the timestamp info to the txt output. I wasn't sure where to place it, I went with "first thing on the line" but I'm not sure I understood the padding system correctly.

Here is what it looks like:

```
              [0.168s]  cy:request (K): GET http://localhost:XXXX/status
                                        Status: 200
                                        Response body: STARTING
              [0.172s]  cy:command (K): its	.body
              [0.181s]  cy:command (K): cypress-recurse	value STARTING
              [0.184s]  cy:command (K): wait	1000, {log: true}
              [1.188s]  cy:command (K): cypress-recurse	remaining **2938** ms and **4** attempts
```

```
       [1707770826394]  cy:command (K): cypress-recurse	value STARTING
       [1707770826397]  cy:command (K): wait	1000, {log: true}
       [1707770827403]  cy:command (K): cypress-recurse	remaining **2952** ms and **4** attempts
       [1707770827418]  cy:request (K): GET http://localhost:XXXX/emulator/status
                                        Status: 200
                                        Response body: STARTING
```

If there's anything I can improve, let me know!

