### PR TITLE
Support patterns in outPath for NestedOutputProcessorDecorator

### DIFF
--- a/src/installLogsPrinter.js
+++ b/src/installLogsPrinter.js
@@ -104,7 +104,7 @@ function installLogsPrinter(on, options = {}) {
         options.printLogsToConsole !== "never" && (
           options.printLogsToConsole === "always"
           || (options.printLogsToConsole === "onFail" && data.state !== "passed")
-          || isHookAndShouldLog
+        || isHookAndShouldLog
         )
       ) {
         logToTerminal(terminalMessages, options, data);
@@ -190,10 +190,7 @@ function installOutputProcessors(on, /** @type {PluginOptions} */ options) {
     }
 
     if (requiresNested) {
-      const parts = file.split('|');
-      const root = parts[0];
-      const ext = parts[1];
-      outputProcessors.push(new NestedOutputProcessorDecorator(root, options.specRoot, ext, (nestedFile) => {
+      outputProcessors.push(new NestedOutputProcessorDecorator(file, options.specRoot, (nestedFile) => {
         return createProcessorFromType(nestedFile, type);
       }));
     } else {

--- a/src/outputProcessor/NestedOutputProcessorDecorator.js
+++ b/src/outputProcessor/NestedOutputProcessorDecorator.js
@@ -2,9 +2,10 @@ const path = require('path');
 
 module.exports = class NestedOutputProcessorDecorator {
 
-  constructor(root, specRoot, ext, decoratedFactory) {
-    this.root = root;
-    this.ext = ext;
+  constructor(filePattern, specRoot, decoratedFactory) {
+	const parts = filePattern.split('|');
+    this.root = parts[0];
+    this.ext = parts[1];
     this.specRoot = specRoot || '';
     this.decoratedFactory = decoratedFactory;
 

--- a/src/outputProcessor/NestedOutputProcessorDecorator.js
+++ b/src/outputProcessor/NestedOutputProcessorDecorator.js
@@ -3,9 +3,16 @@ const path = require('path');
 module.exports = class NestedOutputProcessorDecorator {
 
   constructor(filePattern, specRoot, decoratedFactory) {
-	const parts = filePattern.split('|');
-    this.root = parts[0];
-    this.ext = parts[1];
+    const parts = filePattern.split('|');
+	// for pattern matching: first part of filePattern has to start with '*|'
+	if (parts[0] === "*") {
+		// join all parts, but remove '|'
+		this.pattern = filePattern.substring(2).split('|').join('');
+	} else {
+		// legacy format: path-prefix|extension
+		this.pattern = parts[0]+"/[relpath]/[basename]."+parts[1];
+	}
+
     this.specRoot = specRoot || '';
     this.decoratedFactory = decoratedFactory;
 
@@ -22,7 +29,18 @@ module.exports = class NestedOutputProcessorDecorator {
     }
 
     const relativeSpec = path.relative(this.specRoot, spec);
-    const outPath = path.join(this.root, relativeSpec.replace(new RegExp(path.extname(relativeSpec) + '$'), `.${this.ext}`));
+	
+	const parsed = path.parse(relativeSpec);
+	const relpath = parsed.dir;
+	const basename = parsed.name;
+
+	// replace [*] tokens in pattern to build output filepath
+	var outPath = this.pattern.replace(/\[([^\]]+)\]/g, function(m, cap1) {
+		if (cap1 === "relpath") return relpath;
+		if (cap1 === "basename") return basename;
+		return "-";
+	});
+
     const processor = this.decoratedFactory(outPath);
 
     processor.initialize();


### PR DESCRIPTION
Hey there! I tried to minimize changes to implement patterns in output filenames for custom output:

`outputTarget: { '*|[relpath]/[basename]/[yyyy][mm][dd]/[basename].[HH][MM][SS].txt': function (allMessages) {..} }`
`outputTarget: { '*|[relpath]/[basename].txt': function () {..} }`

Supported are these tokens:
| Token           | Example      | Description |
| ------------- |:-------------:| -------------:|
| [relpath]     | /cy/e2e       | relative path of spec to spec root |
| [basename]    | spec1.cy      | part of spec filename before extension |
| [H]    | "0"    | Hour of day |
| [HH]   | "00"   | Hour of day - with leading zero |
| [M]    | "0"    | Minute of hour |
| [MM]   | "00"   | Minute of hour - with leading zero |
| [S]    | "0"    | Second of minute |
| [SS]   | "00"   | Second of minute - with leading zero |
| [d]    | "1"    | day of month |
| [dd]   | "01"   | day of month - with leading zero |
| [m]    | "1"    | month of year |
| [mm]   | "01"   | month of year - with leading zero |
| [yy]   | "70"   | last 2 digits of current year |
| [yyyy] | "1970" | current year |

The legacy format given as 'path-prefix|extension'
`outputTarget: { 'cypress-logs|txt': function () {..} }`
is translated to pattern:
`parts[0]+"/[relpath]/[basename]."+parts[1]`

Hope this helps someone!