### PR TITLE
Improve javascript compatibility

### DIFF
--- a/src/collector/LogCollectSimpleControl.js
+++ b/src/collector/LogCollectSimpleControl.js
@@ -41,8 +41,8 @@ module.exports = class LogCollectSimpleControl extends LogCollectBaseControl {
       }
     }
 
-    if (testState === 'failed' && mochaRunnable?._retries > 0) {
-      testTitle += ` (Attempt ${mochaRunnable?._currentRetry + 1})`
+    if (testState === 'failed' && mochaRunnable && mochaRunnable._retries > 0) {
+      testTitle += ` (Attempt ${mochaRunnable && mochaRunnable._currentRetry + 1})`
     }
 
     const prepareLogs = () => {


### PR DESCRIPTION
There's just one usage of the `?` optional chaining operator in this package, which was introduced in ES2020.  

I have a large project in which I can't easily upgrade the webpack target ES version, and running master gives the error below. 

This fix will make your awesome package available to more people. :) 

<img width="1543" alt="image" src="https://github.com/user-attachments/assets/e474b3a0-d60b-45c4-b328-d20581e40423">
