### PR TITLE
feat: consoleProcessor accommodate message markdown

### DIFF
--- a/src/outputProcessor/consoleProcessor.ts
+++ b/src/outputProcessor/consoleProcessor.ts
@@ -2,6 +2,7 @@ import CONSTANTS from "../constants";
 import type {Log, LogType, MessageData} from "../types";
 import type {PluginOptions} from "../installLogsPrinter.types";
 import chalk from "chalk";
+import utils from "utils";
 
 const LOG_TYPES = CONSTANTS.LOG_TYPES;
 const KNOWN_TYPES = Object.values(CONSTANTS.LOG_TYPES);
@@ -127,7 +128,7 @@ function consoleProcessor(
     severity,
     timeString
   }) => {
-    let processedMessage = message;
+    let {isItalic, isBold, processedMessage} = utils.checkMessageMarkdown(message);
 
     let {color, icon, trim} = TYPE_COMPUTE[type](options);
     trim = trim || options.defaultTrimLength || 800;
@@ -142,6 +143,12 @@ function consoleProcessor(
 
     if (message.length > trim) {
       processedMessage = message.substring(0, trim) + ' ...';
+    }
+    if (isItalic) {
+      processedMessage = chalk.italic(processedMessage)
+    }
+    if (isBold) {
+      processedMessage = chalk.bold(processedMessage)
     }
 
     if (timeString) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -82,10 +82,31 @@ const utils = {
     return json;
   },
 
-  validatorErrToStr: function (errorList: Failure[]) {
+  validatorErrToStr(errorList: Failure[]) {
     return '\n' + errorList.map((error) => {
       return ` => ${error.path.join('.')}: ${error.message}`;
     }).join('\n') + '\n';
+  },
+
+  /**
+   * The Cypress GUI runner allows markdown in `cy.log` messages. We can take this
+   * into account for our loggers as well.
+   */
+  checkMessageMarkdown(message: string) {
+    let processedMessage = message
+    const isItalic = message.startsWith('_') && message.endsWith('_')
+    const isBold = message.startsWith('**') && message.endsWith('**')
+  
+    // TODO: account for both bold and italic?
+    if (isItalic) {
+      processedMessage = processedMessage.replace(/^_*/,"").replace(/_*$/,"")
+    }
+  
+    if (isBold) {
+      processedMessage = processedMessage.replace(/^(\*\*)*/,"").replace(/(\*\*)*$/,"")
+    }
+
+    return {isItalic, isBold, processedMessage}
   }
 }
 


### PR DESCRIPTION
The Cypress GUI runner allows markdown in `cy.log` messages. We can take this into account for our loggers as well.