### PR TITLE
DRAFT: pass options to outputprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ Inside the function you will have access to the following API:
 // ...
 const options = {
   outputTarget: {
-    'custom.output': function (allMessages) {
+    'custom.output': function (allMessages, options) {
       // allMessages= {[specPath: string]: {[testTitle: string]: [type: string, message: string, severity: string][]}}
 
       Object.entries(allMessages).forEach(([spec, tests]) => {

--- a/src/installLogsCollector.ts
+++ b/src/installLogsCollector.ts
@@ -24,8 +24,8 @@ function installLogsCollector(config: SupportOptions = {}) {
   validateConfig(config);
 
   const extendedConfig: ExtendedSupportOptions = {
+    collectTypes: Object.values(CONSTANTS.LOG_TYPES),
     ...config,
-    collectTypes: config.collectTypes || Object.values(CONSTANTS.LOG_TYPES),
     collectBody: config.xhr?.printBody ?? true,
     collectRequestData: config.xhr?.printRequestData,
     collectHeaderData: config.xhr?.printHeaderData,

--- a/src/installLogsPrinter.ts
+++ b/src/installLogsPrinter.ts
@@ -177,8 +177,8 @@ function installOutputProcessors(on: Cypress.PluginEvents, options: PluginOption
 
   const createProcessorFromType = (
     file: string,
-    options: PluginOptions,
-    type: BuiltinOutputProcessorsTypes | CustomOutputProcessorCallback
+    type: BuiltinOutputProcessorsTypes | CustomOutputProcessorCallback,
+    options: PluginOptions
   ) => {
     const filepath = path.join(options.outputRoot || '', file);
 
@@ -212,11 +212,11 @@ function installOutputProcessors(on: Cypress.PluginEvents, options: PluginOption
           root,
           options.specRoot || '',
           ext,
-          (nestedFile: string) => createProcessorFromType(nestedFile, options, type)
+          (nestedFile: string) => createProcessorFromType(nestedFile, type, options)
         )
       );
     } else {
-      outputProcessors.push(createProcessorFromType(file, options, type));
+      outputProcessors.push(createProcessorFromType(file, type, options));
     }
   });
 

--- a/src/installLogsPrinter.ts
+++ b/src/installLogsPrinter.ts
@@ -164,12 +164,14 @@ function installOutputProcessors(on: Cypress.PluginEvents, options: PluginOption
     options: PluginOptions,
     type: BuiltinOutputProcessorsTypes | CustomOutputProcessorCallback
   ) => {
+    const filepath = path.join(options.outputRoot || '', file);
+
     if (typeof type === 'string') {
-      return new OUTPUT_PROCESSOR_TYPE[type](path.join(options.outputRoot || '', file), options);
+      return new OUTPUT_PROCESSOR_TYPE[type](filepath, options);
     }
 
     if (typeof type === 'function') {
-      return new CustomOutputProcessor(path.join(options.outputRoot || '', file), options, type);
+      return new CustomOutputProcessor(filepath, options, type);
     }
 
     throw new Error('Unexpected type case.');

--- a/src/installLogsPrinter.ts
+++ b/src/installLogsPrinter.ts
@@ -10,16 +10,16 @@ import type {
   PluginOptions,
   AllMessages,
 } from './installLogsPrinter.types';
-import type { BuiltinOutputProcessorsTypes, Log, LogType, MessageData, Severity } from './types';
-import type { IOutputProcecessor } from './outputProcessor/BaseOutputProcessor';
+import type {BuiltinOutputProcessorsTypes, Log, LogType, MessageData, Severity} from './types';
+import type {IOutputProcecessor} from './outputProcessor/BaseOutputProcessor';
 import utils from './utils';
 import consoleProcessor from './outputProcessor/consoleProcessor';
-import { validate } from 'superstruct';
-import { InstallLogsPrinterSchema } from './installLogsPrinter.schema';
+import {validate} from 'superstruct';
+import {InstallLogsPrinterSchema} from './installLogsPrinter.schema';
 
 const OUTPUT_PROCESSOR_TYPE: Record<
   BuiltinOutputProcessorsTypes,
-  { new(file: string, options: PluginOptions): IOutputProcecessor }
+  {new (file: string, options: PluginOptions): IOutputProcecessor}
 > = {
   json: JsonOutputProcessor,
   txt: TextOutputProcessor,
@@ -31,7 +31,7 @@ let outputProcessors: IOutputProcecessor[] = [];
 const createLogger = (enabled?: boolean) =>
   enabled
     ? (message: string) => console.log(`[cypress-terminal-report:debug] ${message}`)
-    : () => { };
+    : () => {};
 
 /**
  * Installs the cypress plugin for printing logs to terminal.
@@ -104,7 +104,7 @@ function installLogsPrinter(on: Cypress.PluginEvents, options: PluginOptions = {
           `Running \`collectTestLogs\` on ${terminalMessages.length} messages, for ${data.spec}:${data.test}.`
         );
         options.collectTestLogs(
-          { spec: data.spec, test: data.test, state: data.state },
+          {spec: data.spec, test: data.test, state: data.state},
           terminalMessages
         );
       }
@@ -253,7 +253,7 @@ function compactLogs(logs: Log[], keepAroundCount: number, logDebug: (message: s
 
 // Ensures backwards compatibility type imports.
 declare namespace installLogsPrinter {
-  export { LogType, Log, Severity, PluginOptions, AllMessages, CustomOutputProcessorCallback };
+  export {LogType, Log, Severity, PluginOptions, AllMessages, CustomOutputProcessorCallback};
 }
 
 export = installLogsPrinter;

--- a/src/installLogsPrinter.ts
+++ b/src/installLogsPrinter.ts
@@ -56,9 +56,10 @@ function installLogsPrinter(on: Cypress.PluginEvents, options: PluginOptions = {
     printLogsToFile,
     printLogsToConsole,
     outputCompactLogs,
-    outputTarget,logToFilesOnAfterRun,
+    outputTarget,
+    logToFilesOnAfterRun,
     includeSuccessfulHookLogs,
-    compactLogs: compactLogsOption,
+    compactLogs,
     collectTestLogs,
   } = resolvedOptions;
 
@@ -80,8 +81,8 @@ function installLogsPrinter(on: Cypress.PluginEvents, options: PluginOptions = {
       let messages = data.messages;
 
       const terminalMessages =
-        typeof compactLogsOption === 'number' && compactLogsOption >= 0
-          ? compactLogs(messages, compactLogsOption, logDebug)
+        typeof compactLogs === 'number' && compactLogs >= 0
+          ? getCompactLogs(messages, compactLogs, logDebug)
           : messages;
 
       const isHookAndShouldLog =
@@ -91,7 +92,7 @@ function installLogsPrinter(on: Cypress.PluginEvents, options: PluginOptions = {
         if (data.state === 'failed' || printLogsToFile === 'always' || isHookAndShouldLog) {
           let outputFileMessages =
             typeof outputCompactLogs === 'number'
-              ? compactLogs(messages, outputCompactLogs, logDebug)
+              ? getCompactLogs(messages, outputCompactLogs, logDebug)
               : outputCompactLogs === false
                 ? messages
                 : terminalMessages;
@@ -222,7 +223,7 @@ function installOutputProcessors(on: Cypress.PluginEvents, options: PluginOption
   outputProcessors.forEach((processor) => processor.initialize());
 }
 
-function compactLogs(logs: Log[], keepAroundCount: number, logDebug: (message: string) => void) {
+function getCompactLogs(logs: Log[], keepAroundCount: number, logDebug: (message: string) => void) {
   logDebug(`Compacting ${logs.length} logs.`);
 
   const failingIndexes = logs

--- a/src/outputProcessor/BaseOutputProcessor.ts
+++ b/src/outputProcessor/BaseOutputProcessor.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import CtrError from '../CtrError';
-import type { AllMessages, PluginOptions } from '../installLogsPrinter.types';
+import type {AllMessages, PluginOptions} from '../installLogsPrinter.types';
 
 export interface IOutputProcecessor {
   initialize(): void;
@@ -18,7 +18,10 @@ export default abstract class BaseOutputProcessor implements IOutputProcecessor 
   protected specChunksWritten: Record<string, [number, number]> = {};
   protected writeSpendTime: number = 0;
 
-  constructor(protected file: string, protected options: PluginOptions) { }
+  constructor(
+    protected file: string,
+    protected options: PluginOptions
+  ) {}
 
   getTarget() {
     return this.file;
@@ -45,7 +48,7 @@ export default abstract class BaseOutputProcessor implements IOutputProcecessor 
 
     const basePath = path.dirname(this.file);
     if (!fs.existsSync(basePath)) {
-      fs.mkdirSync(basePath, { recursive: true });
+      fs.mkdirSync(basePath, {recursive: true});
     }
 
     fs.writeFileSync(this.file, this.initialContent);

--- a/src/outputProcessor/BaseOutputProcessor.ts
+++ b/src/outputProcessor/BaseOutputProcessor.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import CtrError from '../CtrError';
-import type {AllMessages} from '../installLogsPrinter.types';
+import type { AllMessages, PluginOptions } from '../installLogsPrinter.types';
 
 export interface IOutputProcecessor {
   initialize(): void;
@@ -18,7 +18,7 @@ export default abstract class BaseOutputProcessor implements IOutputProcecessor 
   protected specChunksWritten: Record<string, [number, number]> = {};
   protected writeSpendTime: number = 0;
 
-  constructor(protected file: string) {}
+  constructor(protected file: string, protected options: PluginOptions) { }
 
   getTarget() {
     return this.file;
@@ -45,7 +45,7 @@ export default abstract class BaseOutputProcessor implements IOutputProcecessor 
 
     const basePath = path.dirname(this.file);
     if (!fs.existsSync(basePath)) {
-      fs.mkdirSync(basePath, {recursive: true});
+      fs.mkdirSync(basePath, { recursive: true });
     }
 
     fs.writeFileSync(this.file, this.initialContent);

--- a/src/outputProcessor/CustomOutputProcessor.ts
+++ b/src/outputProcessor/CustomOutputProcessor.ts
@@ -1,5 +1,9 @@
 import BaseOutputProcessor, {IOutputProcecessor} from './BaseOutputProcessor';
-import type {AllMessages, CustomOutputProcessorCallback, PluginOptions} from '../installLogsPrinter.types';
+import type {
+  AllMessages,
+  CustomOutputProcessorCallback,
+  PluginOptions,
+} from '../installLogsPrinter.types';
 
 export default class CustomOutputProcessor
   extends BaseOutputProcessor
@@ -7,7 +11,7 @@ export default class CustomOutputProcessor
 {
   constructor(
     file: string,
-    options:PluginOptions,
+    options: PluginOptions,
     protected processorCallback: CustomOutputProcessorCallback
   ) {
     super(file, options);

--- a/src/outputProcessor/CustomOutputProcessor.ts
+++ b/src/outputProcessor/CustomOutputProcessor.ts
@@ -1,5 +1,5 @@
 import BaseOutputProcessor, {IOutputProcecessor} from './BaseOutputProcessor';
-import type {AllMessages, CustomOutputProcessorCallback} from '../installLogsPrinter.types';
+import type {AllMessages, CustomOutputProcessorCallback, PluginOptions} from '../installLogsPrinter.types';
 
 export default class CustomOutputProcessor
   extends BaseOutputProcessor
@@ -7,9 +7,10 @@ export default class CustomOutputProcessor
 {
   constructor(
     file: string,
+    options:PluginOptions,
     protected processorCallback: CustomOutputProcessorCallback
   ) {
-    super(file);
+    super(file, options);
   }
 
   write(allMessages: AllMessages) {

--- a/src/outputProcessor/TextOutputProcessor.ts
+++ b/src/outputProcessor/TextOutputProcessor.ts
@@ -1,13 +1,13 @@
 import BaseOutputProcessor, {IOutputProcecessor} from './BaseOutputProcessor';
 import logsTxtFormatter from './logsTxtFormatter';
 import {EOL} from 'os';
-import type {AllMessages} from '../installLogsPrinter.types';
+import type {AllMessages, PluginOptions} from '../installLogsPrinter.types';
 
 const PADDING = '    ';
 
 export default class TextOutputProcessor extends BaseOutputProcessor implements IOutputProcecessor {
-  constructor(file: string) {
-    super(file);
+  constructor(file: string, options: PluginOptions) {
+    super(file, options);
     this.chunkSeparator = EOL + EOL;
   }
 

--- a/src/outputProcessor/consoleProcessor.ts
+++ b/src/outputProcessor/consoleProcessor.ts
@@ -89,14 +89,15 @@ const getTypeString = (type: LogType, icon: LogSymbols, color: Colors, padding: 
     return TYPE_STRING_CACHE[key];
   }
 
-  const typeString = padType(KNOWN_LOG_TYPES.includes(type) ? type : '[unknown]', padding);
-  const fullString = typeString + icon + ' ';
-  const coloredTypeString = BOLD_COLORS.includes(color)
-    ? chalk[color].bold(fullString)
-    : chalk[color](fullString);
+  let typeString = padType(KNOWN_LOG_TYPES.includes(type) ? type : '[unknown]', padding);
+  typeString += icon + ' ';
+  typeString = chalk[color](typeString);
+  if (BOLD_COLORS.includes(color)) {
+    typeString = chalk.bold(typeString);
+  }
 
-  TYPE_STRING_CACHE[key] = coloredTypeString;
-  return coloredTypeString;
+  TYPE_STRING_CACHE[key] = typeString;
+  return typeString;
 };
 
 function consoleProcessor(messages: Log[], options: PluginOptions, data: MessageData) {

--- a/src/outputProcessor/consoleProcessor.ts
+++ b/src/outputProcessor/consoleProcessor.ts
@@ -53,27 +53,27 @@ const TYPE_COMPUTE: Record<
   [LOG_TYPES.CYPRESS_XHR]: (options) => ({
     color: COLORS.GREEN,
     icon: LOG_SYMBOLS.ROUTE,
-    trim: options.routeTrimLength || 5000,
+    trim: options.routeTrimLength,
   }),
   [LOG_TYPES.CYPRESS_FETCH]: (options) => ({
     color: COLORS.GREEN,
     icon: LOG_SYMBOLS.ROUTE,
-    trim: options.routeTrimLength || 5000,
+    trim: options.routeTrimLength,
   }),
   [LOG_TYPES.CYPRESS_INTERCEPT]: (options) => ({
     color: COLORS.GREEN,
     icon: LOG_SYMBOLS.ROUTE,
-    trim: options.routeTrimLength || 5000,
+    trim: options.routeTrimLength,
   }),
   [LOG_TYPES.CYPRESS_REQUEST]: (options) => ({
     color: COLORS.GREEN,
     icon: LOG_SYMBOLS.SUCCESS,
-    trim: options.routeTrimLength || 5000,
+    trim: options.routeTrimLength,
   }),
   [LOG_TYPES.CYPRESS_COMMAND]: (options) => ({
     color: COLORS.GREEN,
     icon: LOG_SYMBOLS.SUCCESS,
-    trim: options.routeTrimLength || 5000,
+    trim: options.routeTrimLength,
   }),
 };
 
@@ -111,7 +111,7 @@ function consoleProcessor(messages: Log[], options: PluginOptions, data: Message
 
   messages.forEach(({type, message, severity, timeString}) => {
     let processedMessage = message;
-    let {color, icon, trim = options.defaultTrimLength || 800} = TYPE_COMPUTE[type](options);
+    let {color, icon, trim = options.defaultTrimLength} = TYPE_COMPUTE[type](options);
 
     if (severity === CONSTANTS.SEVERITY.ERROR) {
       color = COLORS.RED;
@@ -122,7 +122,7 @@ function consoleProcessor(messages: Log[], options: PluginOptions, data: Message
     }
 
     const maybeTrimLength = (msg: string) =>
-      msg.length > trim ? msg.substring(0, trim) + ' ...' : msg;
+      trim && msg.length > trim ? msg.substring(0, trim) + ' ...' : msg;
 
     if (type == 'cy:log') {
       processedMessage = utils.applyMessageMarkdown(processedMessage, {


### PR DESCRIPTION
Pass options to the outputProcessor. Requires settings defaults the same, but in a different place in the code.

Key example is one might want access to `output.routeTrimLength` which defaults to 5000.